### PR TITLE
캠핑장 구역 상세 페이지 구현

### DIFF
--- a/frontend/m4gi/package-lock.json
+++ b/frontend/m4gi/package-lock.json
@@ -20,6 +20,7 @@
         "react-dom": "^19.0.0",
         "react-router-dom": "^7.5.3",
         "sweetalert2": "^11.22.0",
+        "swiper": "^11.2.8",
         "tailwindcss": "^4.1.4"
       },
       "devDependencies": {
@@ -7087,6 +7088,25 @@
       "funding": {
         "type": "individual",
         "url": "https://github.com/sponsors/limonte"
+      }
+    },
+    "node_modules/swiper": {
+      "version": "11.2.8",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-11.2.8.tgz",
+      "integrity": "sha512-S5FVf6zWynPWooi7pJ7lZhSUe2snTzqLuUzbd5h5PHUOhzgvW0bLKBd2wv0ixn6/5o9vwc/IkQT74CRcLJQzeg==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/swiperjs"
+        },
+        {
+          "type": "open_collective",
+          "url": "http://opencollective.com/swiper"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.7.0"
       }
     },
     "node_modules/tailwindcss": {

--- a/frontend/m4gi/package.json
+++ b/frontend/m4gi/package.json
@@ -25,6 +25,7 @@
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.5.3",
     "sweetalert2": "^11.22.0",
+    "swiper": "^11.2.8",
     "tailwindcss": "^4.1.4"
   },
   "devDependencies": {

--- a/frontend/m4gi/src/App.css
+++ b/frontend/m4gi/src/App.css
@@ -126,6 +126,10 @@
         --checkbox-border: #fca5a5;
     }
 
+    .text-cblack {
+        @apply text-[#141414]
+    }
+
     .text-cpurple {
         @apply text-[#8C06AD]
     }
@@ -384,5 +388,17 @@
         50% {
             opacity: 0.2;
         }
+    }
+
+    .border-cgray {
+        @apply border-[#E5E5E5]
+    }
+
+    .border-cpurple {
+        @apply border-[#8C06AD]
+    }
+
+    .border-clpurple {
+        @apply border-[#EDDDF4]
     }
 }

--- a/frontend/m4gi/src/App.css
+++ b/frontend/m4gi/src/App.css
@@ -170,6 +170,10 @@
         color: #E5E5E5;
     }
 
+    .swiper-pagination {
+        bottom: 1.0rem !important;
+    }
+
     .swiper-pagination-bullet {
         background-color: #E5E5E5 !important;
         opacity: 1;

--- a/frontend/m4gi/src/App.css
+++ b/frontend/m4gi/src/App.css
@@ -149,6 +149,31 @@
     .bg-cgray {
         @apply bg-[#E5E5E5]
     }
+
+    /* Swiper 스타일 */
+    .swiper-button-next {
+        --swiper-navigation-size: 40px;
+        right: 20px !important;
+    }
+    
+    .swiper-button-prev {
+        --swiper-navigation-size: 40px;
+        left: 20px !important;
+    }
+
+    .swiper-button-next::after,
+    .swiper-button-prev::after {
+        color: #E5E5E5;
+    }
+
+    .swiper-pagination-bullet {
+        background-color: #E5E5E5 !important;
+        opacity: 1;
+    }
+
+    .swiper-pagination-bullet-active {
+        background-color: #FFF !important;
+    }
 }
 
 @layer components {

--- a/frontend/m4gi/src/components/Indev/UI/CZ_CampZoneDescription.jsx
+++ b/frontend/m4gi/src/components/Indev/UI/CZ_CampZoneDescription.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { Button } from "../../Common/Button";
 
 export default function CZCampZoneDescription({zoneSiteData}) {
   const [expanded, setExpanded] = useState(false);
@@ -20,8 +21,8 @@ export default function CZCampZoneDescription({zoneSiteData}) {
   const collapsedTextMaxHeight = 'max-h-24'; // 
 
   return (
-    <section className="mt-8 w-full font-bold ">
-      <h2 className="text-2xl text-neutral-900">
+    <section className="mt-8 w-full font-bold mb-4">
+      <h2 className="text-2xl text-cblack">
         구역 소개
       </h2>
       <div className="relative">
@@ -65,8 +66,8 @@ export default function CZCampZoneDescription({zoneSiteData}) {
       </div>
 
       {showMoreButton && (
-        <button 
-        className="flex overflow-hidden justify-center items-center mt-2.5 w-full text-base text-white whitespace-nowrap bg-fuchsia-700 rounded-lg min-h-[40px]"
+        <Button 
+        className="flex overflow-hidden justify-center items-center mt-2.5 w-full text-base text-white whitespace-nowrap bg-cpurple rounded-lg min-h-[40px]"
         onClick = {() => setExpanded(!expanded)}
         >
           <div className="flex gap-2.5 items-center self-stretch my-auto">
@@ -79,7 +80,7 @@ export default function CZCampZoneDescription({zoneSiteData}) {
             alt={expanded ? "접기 화살표" : "더보기 화살표"}
           />
         </div>
-        </button>
+        </Button>
       )}
 
     </section>

--- a/frontend/m4gi/src/components/Indev/UI/CZ_CampZoneDescription.jsx
+++ b/frontend/m4gi/src/components/Indev/UI/CZ_CampZoneDescription.jsx
@@ -21,7 +21,7 @@ export default function CZCampZoneDescription({zoneSiteData}) {
   const collapsedTextMaxHeight = 'max-h-24'; // 
 
   return (
-    <section className="mt-8 w-full font-bold mb-4">
+    <section className="mt-8 w-full font-bold mb-4 select-none">
       <h2 className="text-2xl text-cblack">
         구역 소개
       </h2>

--- a/frontend/m4gi/src/components/Indev/UI/CZ_CampZoneDescription.jsx
+++ b/frontend/m4gi/src/components/Indev/UI/CZ_CampZoneDescription.jsx
@@ -1,0 +1,84 @@
+import React, { useState } from "react";
+
+export default function CZCampZoneDescription({zoneSiteData}) {
+  const [expanded, setExpanded] = useState(false);
+
+  const rawDescription = zoneSiteData?.description || ""; // 옵셔널 체이닝 사용
+
+  // ✨ \\r\\n을 \n으로 변환합니다.
+  const description = rawDescription.replace(/\\r\\n/g, '\n');
+
+  console.log("zoneSiteData : ", zoneSiteData);
+
+  const lineCount = description ? description.split('\n').length : 0;
+  const showMoreButtonThreshold = 5; // 5줄 초과 시 (즉, 6줄부터) 버튼 표시
+
+  // --- 설정값 ---
+  // 축소 시 텍스트의 최대 높이 (예: text-sm 기준 약 5줄)
+  const collapsedTextMaxHeight = 'max-h-24'; // 
+
+  return (
+    <section className="mt-8 w-full font-bold ">
+      <h2 className="text-2xl text-neutral-900">
+        구역 소개
+      </h2>
+      <div className="relative">
+        <p
+          className={`
+            mt-2.5 text-sm text-zinc-500 whitespace-pre-line
+            ${!expanded ? `${collapsedTextMaxHeight} overflow-hidden` : ''}
+          `}
+        >
+          {description}
+        </p>
+
+        {/* 블러 오버레이 - 축소 상태일 때만 표시 */}
+        {!expanded && lineCount > showMoreButtonThreshold && (
+          <div
+            className="absolute bottom-0 left-0 right-0 h-14 pointer-events-none"
+            style={{
+              background: 'linear-gradient(transparent, rgba(255, 255, 255, 0.9))'
+            }}
+          >
+            <div
+              className="absolute inset-0"
+              style={{
+                backdropFilter: 'blur(0.2px)',
+              }}
+            />
+            <div
+              className="absolute inset-0"
+              style={{
+                backdropFilter: 'blur(0.3px)',
+              }}
+            />
+            <div
+              className="absolute inset-0"
+              style={{
+                backdropFilter: 'blur(0.8px)',
+              }}
+            />
+          </div>
+        )}
+      </div>
+
+      {lineCount > showMoreButtonThreshold && (
+      <button
+        className="flex overflow-hidden justify-center items-center mt-2.5 w-full text-base text-white whitespace-nowrap bg-fuchsia-700 rounded-lg min-h-[40px]"
+        onClick={() => setExpanded(!expanded)}
+      >
+        <div className="flex gap-2.5 items-center self-stretch my-auto">
+          <span className="self-stretch my-auto">
+            {expanded ? '접기' : '더보기'}
+          </span>
+          <img
+            src="https://cdn.builder.io/api/v1/image/assets/2e85db91f5bc4c1490f4944382f6bff3/03be2fb3e7426577d4f2a77abdcb9dfb04e5376c?placeholderIfAbsent=true"
+            className={`object-contain shrink-0 self-stretch my-auto w-4 aspect-square transition-transform duration-200 ${expanded ? 'rotate-180' : ''}`}
+            alt={expanded ? "접기 화살표" : "더보기 화살표"}
+          />
+        </div>
+      </button>
+      )}
+    </section>
+  );
+}

--- a/frontend/m4gi/src/components/Indev/UI/CZ_CampZoneDescription.jsx
+++ b/frontend/m4gi/src/components/Indev/UI/CZ_CampZoneDescription.jsx
@@ -11,8 +11,10 @@ export default function CZCampZoneDescription({zoneSiteData}) {
   console.log("zoneSiteData : ", zoneSiteData);
 
   const lineCount = description ? description.split('\n').length : 0;
-  const showMoreButtonThreshold = 5; // 5줄 초과 시 (즉, 6줄부터) 버튼 표시
-
+  const charCount = description.length;
+  // 줄 수가 많거나, 줄바꿈 없이 글자 수가 긴 경우에도 더보기 버튼을 표시하기 위한 혼합 조건
+  const showMoreButton = lineCount > 5 || charCount > 300;
+  
   // --- 설정값 ---
   // 축소 시 텍스트의 최대 높이 (예: text-sm 기준 약 5줄)
   const collapsedTextMaxHeight = 'max-h-24'; // 
@@ -33,7 +35,7 @@ export default function CZCampZoneDescription({zoneSiteData}) {
         </p>
 
         {/* 블러 오버레이 - 축소 상태일 때만 표시 */}
-        {!expanded && lineCount > showMoreButtonThreshold && (
+        {!expanded && showMoreButton && (
           <div
             className="absolute bottom-0 left-0 right-0 h-14 pointer-events-none"
             style={{
@@ -62,12 +64,12 @@ export default function CZCampZoneDescription({zoneSiteData}) {
         )}
       </div>
 
-      {lineCount > showMoreButtonThreshold && (
-      <button
+      {showMoreButton && (
+        <button 
         className="flex overflow-hidden justify-center items-center mt-2.5 w-full text-base text-white whitespace-nowrap bg-fuchsia-700 rounded-lg min-h-[40px]"
-        onClick={() => setExpanded(!expanded)}
-      >
-        <div className="flex gap-2.5 items-center self-stretch my-auto">
+        onClick = {() => setExpanded(!expanded)}
+        >
+          <div className="flex gap-2.5 items-center self-stretch my-auto">
           <span className="self-stretch my-auto">
             {expanded ? '접기' : '더보기'}
           </span>
@@ -77,8 +79,9 @@ export default function CZCampZoneDescription({zoneSiteData}) {
             alt={expanded ? "접기 화살표" : "더보기 화살표"}
           />
         </div>
-      </button>
+        </button>
       )}
+
     </section>
   );
 }

--- a/frontend/m4gi/src/components/Indev/UI/CZ_CampZoneImageSlide.jsx
+++ b/frontend/m4gi/src/components/Indev/UI/CZ_CampZoneImageSlide.jsx
@@ -30,28 +30,26 @@ export default function CZCampZoneImageSlide({ zoneImageJson }) {
   if(imageList.length === 0) return null;
   
   return (
-    <div id="default-carousel" className="relative w-full" data-carousel="slide">
-        <div className="block relative overflow-hidden rounded-lg">
-            <Swiper
-              modules = {[Navigation, Pagination, Autoplay]}
-              navigation
-              pagination = {{ clickable: true }}
-              scrollbar = {{ draggable: true }}
-              autoplay = {{  delay: 4000, disableOnInteraction: true }}
-              loop = {true}
-              className="rouneded-md"
-            >
-            {imageList.map((url, idx) => (
-              <SwiperSlide key = {idx}>
-                <img 
-                  src={url}
-                  alt={`캠핑장 구역 이미지 ${idx + 1}`} 
-                  className="w-full h-[350px] md:h-[500px] object-cover rounded-md" 
-                />
-              </SwiperSlide>
-            ))}
-            </Swiper>
-        </div>
+    <div className="w-full aspect-[2.75] rounded-xl overflow-hidden">
+        <Swiper
+          modules = {[Navigation, Pagination, Autoplay]}
+          navigation
+          pagination = {{ clickable: true }}
+          scrollbar = {{ draggable: true }}
+          autoplay = {{  delay: 4000, disableOnInteraction: true }}
+          loop = {true}
+          className="rouneded-md"
+        >
+        {imageList.map((url, idx) => (
+          <SwiperSlide key = {idx}>
+            <img 
+              src={url}
+              alt={`캠핑장 구역 이미지 ${idx + 1}`} 
+              className="w-full h-[350px] md:h-[500px] object-cover rounded-md" 
+            />
+          </SwiperSlide>
+        ))}
+        </Swiper>
     </div>
   );
 }

--- a/frontend/m4gi/src/components/Indev/UI/CZ_CampZoneImageSlide.jsx
+++ b/frontend/m4gi/src/components/Indev/UI/CZ_CampZoneImageSlide.jsx
@@ -1,0 +1,59 @@
+import React, { useEffect, useRef } from "react";
+import { Swiper, SwiperSlide } from "swiper/react";
+import { Navigation, Pagination, Autoplay } from "swiper/modules";
+import "swiper/css/navigation";
+import "swiper/css/pagination";
+import "swiper/css";
+
+export default function CZCampZoneImageSlide({ zoneImageJson }) {
+  if(!zoneImageJson) return null;
+
+  let imageList = [];
+
+  try {
+      const parsed = JSON.parse(zoneImageJson);
+      const thumbnail = parsed.thumbnail?.[0];
+      const detailImages = parsed.detail || [];
+      
+      console.log("thumbnailImage", thumbnail);
+      console.log("detailImages", detailImages);
+
+      if(thumbnail) {
+        imageList.push(thumbnail);
+      }
+      imageList = [...imageList, ...detailImages];
+  } catch (err) {
+      console.error("zoneImage JSON 파싱 오류 발생: ", err);
+      return null;
+  }
+
+  if(imageList.length === 0) return null;
+  
+  return (
+    <div id="default-carousel" className="relative w-full" data-carousel="slide">
+        <div className="block relative overflow-hidden rounded-lg">
+            <Swiper
+              modules = {[Navigation, Pagination, Autoplay]}
+              navigation
+              pagination = {{ clickable: true }}
+              scrollbar = {{ draggable: true }}
+              autoplay = {{  delay: 4000, disableOnInteraction: true }}
+              loop = {true}
+              className="rouneded-md"
+            >
+            {imageList.map((url, idx) => (
+              <SwiperSlide key = {idx}>
+                <img 
+                  src={url}
+                  alt={`캠핑장 구역 이미지 ${idx + 1}`} 
+                  className="w-full h-[350px] md:h-[500px] object-cover rounded-md" 
+                />
+              </SwiperSlide>
+            ))}
+            </Swiper>
+        </div>
+    </div>
+  );
+}
+
+

--- a/frontend/m4gi/src/components/Indev/UI/CZ_CampZoneInfo.jsx
+++ b/frontend/m4gi/src/components/Indev/UI/CZ_CampZoneInfo.jsx
@@ -1,20 +1,56 @@
 "use client";
 import React from "react";
 
-export default function CampZoneInfo() {
+export default function CZCampZoneInfo( { zoneSiteData } ) {
 
-    {/* const {
-        campground: {
-            campground_name = "",
-            addr_full = "",
-            campground_phone = "",
-            totalWishCount = 0
-        } = {}
-    } = campgroundData || {}; */}
+    // 캠핑 유형 영어 -> 한글 변환
+    const translateZoneType = (type) => {
+        const map = {
+            tent: "캠핑",
+            glamping: "글램핑",
+            auto: "오토캠핑",
+            caravan: "카라반",
+            campnic: "캠프닉"
+        };
+        return map[type] || type;        
+    };
+
+    // 지형 유형 영어 -> 한글 변환
+    const translateTerrainType = (type) => {
+        const map = {
+            Grass: "잔디/흙",
+            Deck: "데크",
+            Gravel: "자갈/파쇄석",
+            Sand: "모래",
+            Mixed: "혼합",
+            Other: "기타"
+        };
+        return map[type] || type;
+    };
     
     return (
-        <section className="w-full max-md:max-w-full">
-            
+        <section className="w-full">
+            <div className="flex flex-wrap gap-3 justify-between items-center w-full">
+                <h2 className="self-stretch my-auto text-2xl font-bold text-cblack">
+                    { zoneSiteData?.zoneName }
+                </h2>
+            </div>
+
+            {/* 캠핑 유형, 지형 유형, 인원수 박스 */}
+            <div className="w-full bg-clpurple rounded-md p-6 flex justify-around items-center text-center mt-4">
+                <div>
+                    <div className="text-cpurple mb-1">캠핑 유형</div>
+                    <div className="text-cblack">{ translateZoneType(zoneSiteData?.zoneType) }</div>
+                </div>
+                <div>
+                    <div className="text-cpurple mb-1">지형 유형</div>
+                    <div className="text-cblack">{ translateTerrainType(zoneSiteData?.zoneTerrainType) }</div>
+                </div>
+                <div>
+                    <div className="text-cpurple mb-1">최대 인원수</div>
+                    <div className="text-cblack">{ zoneSiteData?.capacity } 명</div>
+                </div>
+            </div>
         </section>
     );
 }

--- a/frontend/m4gi/src/components/Indev/UI/CZ_CampZoneInfo.jsx
+++ b/frontend/m4gi/src/components/Indev/UI/CZ_CampZoneInfo.jsx
@@ -1,0 +1,20 @@
+"use client";
+import React from "react";
+
+export default function CampZoneInfo() {
+
+    {/* const {
+        campground: {
+            campground_name = "",
+            addr_full = "",
+            campground_phone = "",
+            totalWishCount = 0
+        } = {}
+    } = campgroundData || {}; */}
+    
+    return (
+        <section className="w-full max-md:max-w-full">
+            
+        </section>
+    );
+}

--- a/frontend/m4gi/src/components/Indev/UI/CZ_CampZoneInfo.jsx
+++ b/frontend/m4gi/src/components/Indev/UI/CZ_CampZoneInfo.jsx
@@ -29,7 +29,7 @@ export default function CZCampZoneInfo( { zoneSiteData } ) {
     };
     
     return (
-        <section className="w-full">
+        <section className="w-full select-none">
             <div className="flex flex-wrap gap-3 justify-between items-center w-full">
                 <h2 className="self-stretch mt-2 mb-4 text-2xl font-bold text-cblack">
                     { zoneSiteData?.zoneName }

--- a/frontend/m4gi/src/components/Indev/UI/CZ_CampZoneInfo.jsx
+++ b/frontend/m4gi/src/components/Indev/UI/CZ_CampZoneInfo.jsx
@@ -31,13 +31,13 @@ export default function CZCampZoneInfo( { zoneSiteData } ) {
     return (
         <section className="w-full">
             <div className="flex flex-wrap gap-3 justify-between items-center w-full">
-                <h2 className="self-stretch my-auto text-2xl font-bold text-cblack">
+                <h2 className="self-stretch mt-2 mb-4 text-2xl font-bold text-cblack">
                     { zoneSiteData?.zoneName }
                 </h2>
             </div>
 
             {/* 캠핑 유형, 지형 유형, 인원수 박스 */}
-            <div className="w-full bg-clpurple rounded-md p-6 flex justify-around items-center text-center mt-4">
+            <div className="w-full bg-clpurple rounded-md p-6 flex justify-around items-center text-center">
                 <div>
                     <div className="text-cpurple mb-1">캠핑 유형</div>
                     <div className="text-cblack">{ translateZoneType(zoneSiteData?.zoneType) }</div>

--- a/frontend/m4gi/src/components/Indev/UI/CZ_CampZoneReviewSection.jsx
+++ b/frontend/m4gi/src/components/Indev/UI/CZ_CampZoneReviewSection.jsx
@@ -1,0 +1,106 @@
+// ZoneReviewSection.jsx
+import React, { useState } from "react";
+import ReviewCard from "../../Main/UI/ReviewCard";
+import StarRating from "../../Common/StarRating";
+
+const formatDateArray = (dateArray) => {
+    if (!dateArray || dateArray.length < 3) return "";
+    const year = dateArray[0];
+    const month = String(dateArray[1]).padStart(2, '0');
+    const day = String(dateArray[2]).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+};
+
+const reviewFirstImage = (reviewURL) => {
+    if (typeof reviewURL !== 'string' || !reviewURL.trim()) {
+        return null;
+    }
+    try {
+        const photoObject = JSON.parse(reviewURL);
+        if (photoObject?.photo_urls?.length > 0) {
+            return photoObject.photo_urls[0];
+        }
+    } catch (e) {
+        console.error("리뷰 사진 JSON 파싱 오류:", e, reviewURL);
+    }
+    return null;
+};
+
+export default function CZCampZoneReviewSection({ zoneData }) {
+    const [showAllReviews, setShowAllReviews] = useState(false);
+
+    const reviews = zoneData?.reviews || [];
+    const zoneName = zoneData?.zoneName || "구역 이름";
+
+    console.log("리뷰 개수:", reviews.length);
+    console.log("리뷰 목록:", reviews);
+
+    const rawAverageRating = reviews.length > 0
+        ? reviews.reduce((sum, r) => sum + Number(r.reviewRating), 0) / reviews.length
+        : 0;
+
+    console.log("리뷰 평균:", rawAverageRating);
+
+    const averageRating = Math.floor(rawAverageRating * 2) / 2;
+    const displayLimit = 3;
+    const displayedReviews = showAllReviews ? reviews : reviews.slice(0, displayLimit);
+
+    return (
+        <section className="mt-8 w-full max-md:max-w-full">
+            <h2 className="gap-2.5 p-2.5 w-full text-2xl font-bold text-neutral-900 max-md:max-w-full">
+                방문 후기
+            </h2>
+
+            <div className="flex flex-col justify-center px-2.5 py-5 mt-8 w-full text-center max-md:max-w-full">
+                <div className="w-full max-md:max-w-full">
+                    <p className="text-2xl font-bold text-fuchsia-700 max-md:max-w-full">
+                        <StarRating rating={averageRating} readOnly={true} />
+                    </p>
+                    <p className="mt-1.5 text-sm text-zinc-500 max-md:max-w-full">
+                        {reviews.length}명 평가
+                    </p>
+                </div>
+            </div>
+
+            <div className="mt-8 text-sm text-right text-fuchsia-700 max-md:max-w-full">
+                {reviews.length > displayLimit && (
+                    <button
+                        onClick={() => setShowAllReviews(!showAllReviews)}
+                        aria-expanded={showAllReviews}
+                        aria-controls="zone-reviews-list"
+                    >
+                        {showAllReviews ? "간략히 보기" : "전체 보기"}
+                    </button>
+                )}
+            </div>
+
+            <div className="mt-8 w-full max-md:max-w-full" id="zone-reviews-list">
+                {reviews.length > 0 ? (
+                    displayedReviews.map((reviewItem) => {
+                        const url = reviewFirstImage(reviewItem.reviewPhotosJson);
+                        const reviewDate = formatDateArray(reviewItem.createdAt);
+
+                        return (
+                            <ReviewCard
+                                key={reviewItem.reviewId}
+                                review={{
+                                    campName: zoneName,
+                                    site: reviewItem.siteName || "사이트",
+                                    content: reviewItem.reviewContent,
+                                    score: reviewItem.reviewRating.toString(),
+                                    author: reviewItem.providerUserId || "익명",
+                                    date: reviewDate,
+                                }}
+                                variant="long"
+                                image={url}
+                                site={reviewItem.siteName || "사이트"}
+                            />
+                        );
+                    })
+                ) : (
+                    <p className="text-center text-neutral-500 py-10">아직 작성된 리뷰가 없습니다.</p>
+                )}
+            </div>
+        </section>
+    );
+}

--- a/frontend/m4gi/src/components/Indev/UI/CZ_CampZoneReviewSection.jsx
+++ b/frontend/m4gi/src/components/Indev/UI/CZ_CampZoneReviewSection.jsx
@@ -46,23 +46,23 @@ export default function CZCampZoneReviewSection({ zoneData }) {
     const displayedReviews = showAllReviews ? reviews : reviews.slice(0, displayLimit);
 
     return (
-        <section className="mt-8 w-full max-md:max-w-full">
-            <h2 className="gap-2.5 p-2.5 w-full text-2xl font-bold text-neutral-900 max-md:max-w-full">
+        <section className="mt-8 w-full select-none">
+            <h2 className="gap-2.5 p-2.5 w-full text-2xl font-bold text-cblack">
                 방문 후기
             </h2>
 
-            <div className="flex flex-col justify-center px-2.5 py-5 mt-8 w-full text-center max-md:max-w-full">
-                <div className="w-full max-md:max-w-full">
-                    <p className="text-2xl font-bold text-fuchsia-700 max-md:max-w-full">
+            <div className="flex flex-col justify-center px-2.5 py-5 mt-8 w-full text-center">
+                <div className="w-full">
+                    <p className="text-2xl font-bold text-cpurple">
                         <StarRating rating={averageRating} readOnly={true} />
                     </p>
-                    <p className="mt-1.5 text-sm text-zinc-500 max-md:max-w-full">
+                    <p className="mt-1.5 text-sm text-zinc-500">
                         {reviews.length}명 평가
                     </p>
                 </div>
             </div>
 
-            <div className="mt-8 text-sm text-right text-fuchsia-700 max-md:max-w-full">
+            <div className="mt-8 text-sm text-right text-cpurple">
                 {reviews.length > displayLimit && (
                     <button
                         onClick={() => setShowAllReviews(!showAllReviews)}
@@ -74,7 +74,7 @@ export default function CZCampZoneReviewSection({ zoneData }) {
                 )}
             </div>
 
-            <div className="mt-8 w-full max-md:max-w-full" id="zone-reviews-list">
+            <div className="mt-8 w-full" id="zone-reviews-list">
                 {reviews.length > 0 ? (
                     displayedReviews.map((reviewItem) => {
                         const url = reviewFirstImage(reviewItem.reviewPhotosJson);

--- a/frontend/m4gi/src/components/Indev/UI/CZ_SiteSelectionCard.jsx
+++ b/frontend/m4gi/src/components/Indev/UI/CZ_SiteSelectionCard.jsx
@@ -1,11 +1,12 @@
 import React from "react";
 
 export default function SiteSelectionCard({ site, siteTerrainType, isSelected, onSelect }) {
-    const isUnavailable = !site.isActive;
-
+    const isUnavailable = !site.isActive || !site.isAvailable;
+    console.log("🟡 카드 표시 상태:", site.siteId, "isActive:", site.isActive, "isAvailable:", site.isAvailable, "→ 회색?", isUnavailable);
+    
     // 사이트 예약 가능 여부, 사이트 선택에 따른 텍스트 색상 설정
     const textColor = isUnavailable ? "text-gray-400" : isSelected ? "text-cpurple" : "text-cblack";
-
+    
     // 지형 유형 영어 -> 한글 변환
     const translateTerrainType = (type) => {
         const map = {
@@ -22,7 +23,7 @@ export default function SiteSelectionCard({ site, siteTerrainType, isSelected, o
     return (
         <div
             key = {site.siteId}
-            onClick = {() => onSelect(site.siteId, site.isActive)}
+            onClick = {() => onSelect(site.siteId, site.isActive && site.isAvailable)}
             className = {`
                 w-40 border border-cgray rounded-xl px-6 py-7 
                 flex flex-col items-center justify-center cursor-pointer                

--- a/frontend/m4gi/src/components/Indev/UI/CZ_SiteSelectionCard.jsx
+++ b/frontend/m4gi/src/components/Indev/UI/CZ_SiteSelectionCard.jsx
@@ -1,0 +1,47 @@
+import React from "react";
+
+export default function SiteSelectionCard({ site, siteTerrainType, isSelected, onSelect }) {
+    const isUnavailable = !site.isActive;
+
+    // 사이트 예약 가능 여부, 사이트 선택에 따른 텍스트 색상 설정
+    const textColor = isUnavailable ? "text-gray-400" : isSelected ? "text-cpurple" : "text-cblack";
+
+    // 지형 유형 영어 -> 한글 변환
+    const translateTerrainType = (type) => {
+        const map = {
+            Grass: "잔디/흙",
+            Deck: "데크",
+            Gravel: "자갈/파쇄석",
+            Sand: "모래",
+            Mixed: "혼합",
+            Other: "기타"
+        };
+        return map[type] || type;
+    };
+
+    return (
+        <div
+            key = {site.siteId}
+            onClick = {() => onSelect(site.siteId, site.isActive)}
+            className = {`
+                w-40 border border-cgray rounded-xl px-6 py-7 
+                flex flex-col items-center justify-center cursor-pointer                
+                ${isSelected ? 'bg-clpurple text-cpurple border-clpurple' : ''}
+                ${isUnavailable ? 'opacity-30 cursor-not-allowed' : 'hover:shadow-md'}
+            `}
+        >
+        <p className = {`mb-6 ${textColor}`}>{site.siteName}</p>
+        <p className = {`flex gap-3 items-center text-sm mb-2 ${textColor}`} >
+            {translateTerrainType(siteTerrainType)}
+        </p>
+        <p className = {`flex gap-3 items-center text-sm mb-2 ${textColor}`} >
+            <span className = "flex items-center">
+                {site.widthMeters} x {site.heightMeters} m
+            </span>
+        </p>
+        <p className = {`flex gap-3 items-center text-sm mb-2 ${textColor}`} >
+            <span className = "flex items-center">최대 {site.capacity}명</span>
+        </p>
+        </div>
+    );
+}

--- a/frontend/m4gi/src/components/Indev/UI/CZ_SiteSelectionSection.jsx
+++ b/frontend/m4gi/src/components/Indev/UI/CZ_SiteSelectionSection.jsx
@@ -13,7 +13,7 @@ export default function CZ_SiteSelectionSection({ zoneSiteData }) {
 
     return (
     <section className="w-full mt-8">
-        <h2 className="text-xl font-bold text-cblack mb-4">사이트 선택</h2>
+        <h2 className="text-2xl font-bold text-cblack mb-4">사이트 선택</h2>
         <div className="grid grid-cols-7 place-items-center">
             {siteList.map((site) => (
                 <SiteSelectionCard 
@@ -27,7 +27,7 @@ export default function CZ_SiteSelectionSection({ zoneSiteData }) {
         </div>
         <button
             disabled={!selectedSiteId}
-            className="mt-8 w-full bg-fuchsia-700 text-white rounded-lg py-3 text-center disabled:opacity-50 disabled:cursor-not-allowed"
+            className="mt-8 w-full bg-cpurple text-white rounded-lg py-3 text-center cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
             onClick={() => alert(`예약 진행: ${selectedSiteId}`)}   // TODO : 임시 코드, 수정 필요
         >
         예약하기

--- a/frontend/m4gi/src/components/Indev/UI/CZ_SiteSelectionSection.jsx
+++ b/frontend/m4gi/src/components/Indev/UI/CZ_SiteSelectionSection.jsx
@@ -1,0 +1,37 @@
+import React, { useState } from "react";
+import SiteSelectionCard from "./CZ_SiteSelectionCard";
+
+export default function CZ_SiteSelectionSection({ zoneSiteData }) {
+    const [selectedSiteId, setSelectedSiteId] = useState(null);
+    if(!zoneSiteData || !zoneSiteData.sites) return null;
+    const siteList = zoneSiteData.sites;
+
+    const handleSelect = (siteId, isAvailable) => {
+        if(!isAvailable) return;    // 예약 불가일 경우 선택 불가
+        setSelectedSiteId(siteId);
+    };
+
+    return (
+    <section className="w-full mt-8">
+        <h2 className="text-xl font-bold text-cblack mb-4">사이트 선택</h2>
+        <div className="grid grid-cols-7 place-items-center">
+            {siteList.map((site) => (
+                <SiteSelectionCard 
+                    key = {site.siteId}
+                    site = {site}
+                    siteTerrainType = {zoneSiteData.zoneTerrainType}
+                    isSelected = {selectedSiteId === site.siteId}
+                    onSelect = {handleSelect}
+                />
+            ))}
+        </div>
+        <button
+            disabled={!selectedSiteId}
+            className="mt-8 w-full bg-fuchsia-700 text-white rounded-lg py-3 text-center disabled:opacity-50 disabled:cursor-not-allowed"
+            onClick={() => alert(`예약 진행: ${selectedSiteId}`)}   // TODO : 임시 코드, 수정 필요
+        >
+        예약하기
+        </button>
+    </section>
+  );
+}

--- a/frontend/m4gi/src/components/Indev/UI/CZ_SiteSelectionSection.jsx
+++ b/frontend/m4gi/src/components/Indev/UI/CZ_SiteSelectionSection.jsx
@@ -1,24 +1,46 @@
 import React, { useState } from "react";
 import SiteSelectionCard from "./CZ_SiteSelectionCard";
+import { useNavigate } from "react-router-dom";
 
-export default function CZ_SiteSelectionSection({ zoneSiteData }) {
+export default function CZ_SiteSelectionSection({ zoneSiteData, availableSiteIds, startDate, endDate, people }) {
+    const navigate = useNavigate();
+    
     const [selectedSiteId, setSelectedSiteId] = useState(null);
     if(!zoneSiteData || !zoneSiteData.sites) return null;
     const siteList = zoneSiteData.sites;
 
+    // 사이트 선택 시 실행
     const handleSelect = (siteId, isAvailable) => {
         if(!isAvailable) return;    // 예약 불가일 경우 선택 불가
         setSelectedSiteId(siteId);
     };
 
+    // 예약 페이지로 이동  * Todo: 주소 수정 필요
+    const handleReserve = (selectedSiteId) => {
+        if (!selectedSiteId) return;
+
+        navigate(`/reservation`, {
+            state: {
+                siteId: selectedSiteId,
+                zoneId: zoneSiteData.zoneId,
+                startDate,
+                endDate,
+                people
+            },
+        });
+    };
+    
     return (
-    <section className="w-full mt-8">
+    <section className="w-full mt-8 select-none">
         <h2 className="text-2xl font-bold text-cblack mb-4">사이트 선택</h2>
         <div className="grid grid-cols-7 place-items-center">
             {siteList.map((site) => (
                 <SiteSelectionCard 
                     key = {site.siteId}
-                    site = {site}
+                    site = {{
+                        ...site,
+                        isAvailable: availableSiteIds.includes(site.siteId),
+                    }}
                     siteTerrainType = {zoneSiteData.zoneTerrainType}
                     isSelected = {selectedSiteId === site.siteId}
                     onSelect = {handleSelect}
@@ -26,9 +48,10 @@ export default function CZ_SiteSelectionSection({ zoneSiteData }) {
             ))}
         </div>
         <button
+            type="button"
             disabled={!selectedSiteId}
             className="mt-8 w-full bg-cpurple text-white rounded-lg py-3 text-center cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-            onClick={() => alert(`예약 진행: ${selectedSiteId}`)}   // TODO : 임시 코드, 수정 필요
+            onClick = {() => handleReserve(selectedSiteId)}
         >
         예약하기
         </button>

--- a/frontend/m4gi/src/components/Indev/UI/CampMapSection.jsx
+++ b/frontend/m4gi/src/components/Indev/UI/CampMapSection.jsx
@@ -5,11 +5,17 @@ export default function CampMapSection({ mapImageUrl }) {
     <section className="w-full my-10">
       <h3 className="text-2xl text-cblack mb-4">캠핑장 지도</h3>
       <div className="w-200 mx-auto">
-        <img
-          src={mapImageUrl}
-          alt="캠핑장 지도"
-          className="w-full h-auto rounded-lg object-cover"
-        />
+        {mapImageUrl ? (
+          <img  
+            src = {mapImageUrl}
+            alt = "캠핑장 지도"
+            className="w-full h-auto object-cover"
+          />
+        ) : (
+          <div className="aspect-[3/2] no-image mx-auto w-130 object-cover select-none">
+            <span className="text-gray-500 text-sm">지도가 등록되지 않았습니다</span>
+          </div>
+        )}
       </div>
     </section>
   );

--- a/frontend/m4gi/src/components/Indev/UI/CampMapSection.jsx
+++ b/frontend/m4gi/src/components/Indev/UI/CampMapSection.jsx
@@ -1,0 +1,16 @@
+import React from "react";
+
+export default function CampMapSection({ mapImageUrl }) {
+  return (
+    <section className="w-full my-10">
+      <h3 className="text-xl font-semibold text-cblack mb-4">캠핑장 지도</h3>
+      <div className="w-full mx-auto">
+        <img
+          src={mapImageUrl}
+          alt="캠핑장 지도"
+          className="w-full h-auto rounded-lg object-cover"
+        />
+      </div>
+    </section>
+  );
+}

--- a/frontend/m4gi/src/components/Indev/UI/CampMapSection.jsx
+++ b/frontend/m4gi/src/components/Indev/UI/CampMapSection.jsx
@@ -3,8 +3,8 @@ import React from "react";
 export default function CampMapSection({ mapImageUrl }) {
   return (
     <section className="w-full my-10">
-      <h3 className="text-xl font-semibold text-cblack mb-4">캠핑장 지도</h3>
-      <div className="w-full mx-auto">
+      <h3 className="text-2xl text-cblack mb-4">캠핑장 지도</h3>
+      <div className="w-200 mx-auto">
         <img
           src={mapImageUrl}
           alt="캠핑장 지도"

--- a/frontend/m4gi/src/components/Indev/UI/CampMapSection.jsx
+++ b/frontend/m4gi/src/components/Indev/UI/CampMapSection.jsx
@@ -1,15 +1,20 @@
-import React from "react";
+import React, {useState} from "react";
 
 export default function CampMapSection({ mapImageUrl }) {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
   return (
     <section className="w-full my-10">
       <h3 className="text-2xl text-cblack mb-4">캠핑장 지도</h3>
-      <div className="w-200 mx-auto">
+
+      {/* 지도 */}
+      <div className="w-150 mx-auto">
         {mapImageUrl ? (
           <img  
             src = {mapImageUrl}
             alt = "캠핑장 지도"
-            className="w-full h-auto object-cover"
+            className = "w-full h-auto object-cover"
+            onClick = {() => setIsModalOpen(true)}
           />
         ) : (
           <div className="aspect-[3/2] no-image mx-auto w-130 object-cover select-none">
@@ -17,6 +22,25 @@ export default function CampMapSection({ mapImageUrl }) {
           </div>
         )}
       </div>
+
+      {/* 지도 모달창 */}
+      {isModalOpen &&(
+        <div className="fixed inset-0 backdrop-blur bg-opacity-50 flex items-center justify-center z-50" onClick={() => setIsModalOpen(false)}>
+          <div className="bg-white rounded-md shadow-lg p-4 relative max-w-[90%] max-h-[90%]" onClick={(e) => e.stopPropagation()}>
+            <button
+              className="absolute top-2 right-2 text-gray-400 hover:text-black text-2xl"
+              onClick={() => setIsModalOpen(false)}
+            >
+              &times;
+            </button>
+            <img
+              src={mapImageUrl}
+              alt="확대된 캠핑장 지도"
+              className="max-w-full max-h-[80vh] object-contain"
+            />
+          </div>
+        </div>
+      )}
     </section>
   );
 }

--- a/frontend/m4gi/src/components/Main/UI/Card.jsx
+++ b/frontend/m4gi/src/components/Main/UI/Card.jsx
@@ -6,7 +6,6 @@ import { useSearchParams } from "react-router-dom";
 
 export default function Card({ site, variant = '' }) {
     const navigate = useNavigate();
-    const [searchParams] = useSearchParams();
     const { id, name, location, type, score, price, remainingSpots, image, isNew, isWishlisted } = site;
 
     // 캠핑장 카드 클릭 시, 해당 캠핑장으로 이동

--- a/frontend/m4gi/src/components/Main/UI/Card.jsx
+++ b/frontend/m4gi/src/components/Main/UI/Card.jsx
@@ -2,7 +2,6 @@ import { Badge } from "../../Common/Badge";
 import StarRating from "../../Common/StarRating";
 import LazyImage from "./LazyImage";
 import { useNavigate } from "react-router-dom";
-import { useSearchParams } from "react-router-dom";
 
 export default function Card({ site, variant = '' }) {
     const navigate = useNavigate();
@@ -15,10 +14,9 @@ export default function Card({ site, variant = '' }) {
 
     // 캠핑장 상세 페이지 내 "구역 카드 UI(variant === long)"의 예약하기 버튼 클릭 시, 해당 상세 페이지로 이동
     const handleZoneClick = () => {
+        const params = new URLSearchParams({startDate, endDate, people});
         if (variant === "long" && remainingSpots > 0) {
-            navigate(`/detail/${id}/${zoneId}`, {
-                state: { startDate, endDate, people },
-            });
+            navigate(`/detail/${id}/${zoneId}?${params.toString()}`);
         }
     };
 

--- a/frontend/m4gi/src/components/Main/UI/Card.jsx
+++ b/frontend/m4gi/src/components/Main/UI/Card.jsx
@@ -2,15 +2,26 @@ import { Badge } from "../../Common/Badge";
 import StarRating from "../../Common/StarRating";
 import LazyImage from "./LazyImage";
 import { useNavigate } from "react-router-dom";
+import { useSearchParams } from "react-router-dom";
 
 export default function Card({ site, variant = '' }) {
     const navigate = useNavigate();
+    const [searchParams] = useSearchParams();
     const { id, name, location, type, score, price, remainingSpots, image, isNew, isWishlisted } = site;
-    
+
     // 캠핑장 카드 클릭 시, 해당 캠핑장으로 이동
     const handleCardClick = () => {
         navigate(`/detail/${id}`); // id = 캠핑장 아이디 
     }
+
+    // 캠핑장 상세 페이지 내 "구역 카드 UI(variant === long)"의 예약하기 버튼 클릭 시, 해당 상세 페이지로 이동
+    const handleZoneClick = () => {
+        if (variant === "long" && remainingSpots > 0) {
+            navigate(`/detail/${id}/${zoneId}`, {
+                state: { startDate, endDate, people },
+            });
+        }
+    };
 
     if (variant === 'small') {
         return (
@@ -107,7 +118,7 @@ export default function Card({ site, variant = '' }) {
                                     </p>
                                 </div>
                                 {remainingSpots > 0 ? (
-                                    <button className="overflow-hidden py-2.5 pr-10 pl-10 mt-5 w-full text-base font-bold text-white bg-fuchsia-700 rounded-lg min-h-10">
+                                    <button className="overflow-hidden py-2.5 pr-10 pl-10 mt-5 w-full text-base font-bold text-white bg-fuchsia-700 rounded-lg min-h-10" onClick={ handleZoneClick }>
                                         예약 하기
                                     </button>
                                 ) : (

--- a/frontend/m4gi/src/pages/Indev/CampDetailPage.jsx
+++ b/frontend/m4gi/src/pages/Indev/CampDetailPage.jsx
@@ -17,7 +17,7 @@ const siteA = {
   name: "캠핑 A동",
   price: "40000",
   remainingSpots: 4,
-  image: "https://cdn.builder.io/api/v1/image/assets/2e85db91f5bc4c1490f4944382f6bff3/6b21b804914c0c9f7786ebc82550e078fd82efad?placeholderIfAbsent=true",
+  image: "htps://cdn.builder.io/api/v1/image/assets/2e85db91f5bc4c1490f4944382f6bff3/6b21b804914c0c9f7786ebc82550e078fd82efad?placeholderIfAbsent=true",
 };
 
 const siteB = {
@@ -29,7 +29,7 @@ const siteB = {
 
 export default function CampDetailPage() {
   const { campgroundId } = useParams();
-  const [campgroundData, setCampgroundData] = useState(null);
+  const [ campgroundData, setCampgroundData] = useState(null);
 
   useEffect(() => {
     const CampgroundData = async () => {

--- a/frontend/m4gi/src/pages/Indev/CampDetailPage.jsx
+++ b/frontend/m4gi/src/pages/Indev/CampDetailPage.jsx
@@ -30,6 +30,9 @@ const siteB = {
 export default function CampDetailPage() {
   const { campgroundId } = useParams();
   const [ campgroundData, setCampgroundData] = useState(null);
+  const [startDate, setStartDate] = useState(null);
+  const [endDate, setEndDate] = useState(null);
+  const [people, setPeople] = useState(2); // 기본값 2명
 
   useEffect(() => {
     const CampgroundData = async () => {
@@ -74,18 +77,28 @@ export default function CampDetailPage() {
             <h2 className="gap-2.5 p-2.5 w-full text-2xl font-bold text-neutral-900 max-md:max-w-full">
               상품 예약
             </h2>
-            <Calendar />
-            <DatePersonSelector />
+            <Calendar setStartDate={setStartDate} setEndDate={setEndDate} />
+            <DatePersonSelector setPeople={setPeople} />
           </section>
           <section className="mt-8 w-full max-md:max-w-full">
-            <Card site={siteA} variant='long' />
+            <Card
+              site={siteA} variant='long'
+              startDate={startDate}
+              endDate={endDate}
+              people={people} 
+            />
             <CampSiteAttribute
               type="캠핑"
               maxPeople={6}
               deckType="데크"
               size="5 x 6 m"
             />
-            <Card site={siteB} variant='long'/>
+            <Card 
+              site={siteB} variant='long' 
+              startDate={startDate}
+              endDate={endDate}
+              people={people}
+            />
             <CampSiteAttribute
               type="캠핑"
               maxPeople={6}

--- a/frontend/m4gi/src/pages/Indev/CampZoneDetailPage.jsx
+++ b/frontend/m4gi/src/pages/Indev/CampZoneDetailPage.jsx
@@ -1,0 +1,51 @@
+// CampDetailPage.jsx
+import React, { useState, useEffect } from "react";
+import axios from 'axios';
+import { useParams } from "react-router-dom";
+import Header from "../../components/Common/Header";
+import CampZoneInfo from "../../components/Indev/UI/CZ_CampZoneInfo";
+import ReviewSection from "../../components/Indev/UI/ReviewSection";
+import SiteDescription from "../../components/Indev/UI/SiteDescription";
+import CampZoneDescription from "../../components/Indev/UI/CZ_CampZoneDescription";
+import CampZoneImageSlide from "../../components/Indev/UI/CZ_CampZoneImageSlide";
+
+export default function CampZoneDetailPage() {
+  const { campgroundId } = useParams();
+  const { zoneId } = useParams();
+
+  const [zoneSiteData, setZoneSiteData] = useState();
+
+  // 데이터 가져오기
+  useEffect(() => {
+    const getZoneSiteData = async () => {
+      try {
+        const response = await axios.get(`/web/api/campgrounds/${campgroundId}/zones/${zoneId}`);
+        const data = response.data;
+
+        setZoneSiteData(data);
+
+      } catch (err) {
+        console.error("구역, 사이트 정보를 가져오는 데 실패했습니다 (axios):", err);
+        setZoneSiteData(null);
+      }
+    };
+
+    getZoneSiteData();
+  }, [campgroundId, zoneId]);
+
+  return (
+    <main className="flex overflow-hidden flex-col bg-white">
+      <Header />
+      <section className="flex-1 px-20 py-12 w-full max-md:px-5 max-md:max-w-full">
+        <figure className="flex gap-2.5 items-center p-2.5 w-full rounded-xl max-md:max-w-full">
+          <CampZoneImageSlide zoneImageJson={zoneSiteData?.zoneImage} />
+        </figure>
+        <article className="flex-1 px-10 mt-2.5 w-full max-md:px-5 max-md:max-w-full">
+          { /*<CampZoneInfo zoneSiteData={zoneSiteData} /> */ }
+          <CampZoneDescription zoneSiteData={zoneSiteData} />
+          {/* <ReviewSection zoneSiteData={zoneSiteData} /> */}
+        </article>
+      </section>
+    </main>
+  );
+}

--- a/frontend/m4gi/src/pages/Indev/CampZoneDetailPage.jsx
+++ b/frontend/m4gi/src/pages/Indev/CampZoneDetailPage.jsx
@@ -52,7 +52,7 @@ export default function CampZoneDetailPage() {
     <main className = "flex overflow-hidden flex-col bg-white">
       <Header />
       <section className = "flex-1 px-20 py-12 w-full max-md:px-5">
-        <figure className = "flex gap-2.5 items-center p-2.5 w-full rounded-xl">
+        <figure className = "w-full rounded-xl overflow-hidden">
           <CampZoneImageSlide zoneImageJson={zoneSiteData?.zoneImage} />
         </figure>
         <article className = "flex-1 mt-2.5 w-full max-md:px-2.5">

--- a/frontend/m4gi/src/pages/Indev/CampZoneDetailPage.jsx
+++ b/frontend/m4gi/src/pages/Indev/CampZoneDetailPage.jsx
@@ -21,7 +21,7 @@ export default function CampZoneDetailPage() {
   useEffect(() => {
     const getZoneSiteData = async () => {
       try {
-        const response = await axios.get(`/web/api/campgrounds/${campgroundId}/zones/${zoneId}`);
+        const response = await axios.get(`/web/api/zones/${zoneId}`);
         const data = response.data;
 
         setZoneSiteData(data);
@@ -39,7 +39,7 @@ export default function CampZoneDetailPage() {
   useEffect(() => {
     const getCampgroundMapImg = async () => {
       try {
-        const response = await axios.get(`/web/api/campgrounds/${campgroundId}/mapImage`);
+        const response = await axios.get(`/web/api/campgrounds/${campgroundId}/map-image`);
         setMapImageURL(response.data);
       } catch (err) {
         console.error("캠핑장 지도 URL을 가져오는데 실패했습니다 (axios):", err);

--- a/frontend/m4gi/src/pages/Indev/CampZoneDetailPage.jsx
+++ b/frontend/m4gi/src/pages/Indev/CampZoneDetailPage.jsx
@@ -4,16 +4,18 @@ import axios from 'axios';
 import { useParams } from "react-router-dom";
 import Header from "../../components/Common/Header";
 import CampZoneInfo from "../../components/Indev/UI/CZ_CampZoneInfo";
-import ReviewSection from "../../components/Indev/UI/ReviewSection";
+import ReviewSection from "../../components/Indev/UI/CZ_CampZoneReviewSection";
 import SiteDescription from "../../components/Indev/UI/SiteDescription";
 import CampZoneDescription from "../../components/Indev/UI/CZ_CampZoneDescription";
 import CampZoneImageSlide from "../../components/Indev/UI/CZ_CampZoneImageSlide";
+import CampMapSection from "../../components/Indev/UI/CampMapSection";
+import SiteSelectionSection from "../../components/Indev/UI/CZ_SiteSelectionSection";
 
 export default function CampZoneDetailPage() {
   const { campgroundId } = useParams();
   const { zoneId } = useParams();
-
   const [zoneSiteData, setZoneSiteData] = useState();
+  const [mapImageURL, setMapImageURL] = useState();
 
   // 데이터 가져오기
   useEffect(() => {
@@ -33,17 +35,32 @@ export default function CampZoneDetailPage() {
     getZoneSiteData();
   }, [campgroundId, zoneId]);
 
+  // 데이터 가져오기 - 캠핑장 지도 이미지 URL
+  useEffect(() => {
+    const getCampgroundMapImg = async () => {
+      try {
+        const response = await axios.get(`/web/api/campgrounds/${campgroundId}/mapImage`);
+        setMapImageURL(response.data);
+      } catch (err) {
+        console.error("캠핑장 지도 URL을 가져오는데 실패했습니다 (axios):", err);
+      }
+    }
+    getCampgroundMapImg();
+  }, [campgroundId]);
+
   return (
-    <main className="flex overflow-hidden flex-col bg-white">
+    <main className = "flex overflow-hidden flex-col bg-white">
       <Header />
-      <section className="flex-1 px-20 py-12 w-full max-md:px-5 max-md:max-w-full">
-        <figure className="flex gap-2.5 items-center p-2.5 w-full rounded-xl max-md:max-w-full">
+      <section className = "flex-1 px-20 py-12 w-full max-md:px-5">
+        <figure className = "flex gap-2.5 items-center p-2.5 w-full rounded-xl">
           <CampZoneImageSlide zoneImageJson={zoneSiteData?.zoneImage} />
         </figure>
-        <article className="flex-1 px-10 mt-2.5 w-full max-md:px-5 max-md:max-w-full">
-          { /*<CampZoneInfo zoneSiteData={zoneSiteData} /> */ }
-          <CampZoneDescription zoneSiteData={zoneSiteData} />
-          {/* <ReviewSection zoneSiteData={zoneSiteData} /> */}
+        <article className = "flex-1 mt-2.5 w-full max-md:px-2.5">
+          <CampZoneInfo zoneSiteData = {zoneSiteData} />
+          <CampZoneDescription zoneSiteData = {zoneSiteData} />
+          <CampMapSection mapImageUrl = {mapImageURL}/>
+          <SiteSelectionSection zoneSiteData = {zoneSiteData} />
+          <ReviewSection zoneData = {zoneSiteData} />
         </article>
       </section>
     </main>

--- a/frontend/m4gi/src/pages/Indev/CampZoneDetailPage.jsx
+++ b/frontend/m4gi/src/pages/Indev/CampZoneDetailPage.jsx
@@ -28,7 +28,7 @@ export default function CampZoneDetailPage() {
   useEffect(() => {
     const getZoneSiteData = async () => {
       try {
-        const response = await axios.get(`/web/api/zones/${zoneId}`);
+        const response = await axios.get(`/web/api/campgrounds/${campgroundId}/zones/${zoneId}`);
         const data = response.data;
 
         setZoneSiteData(data);

--- a/frontend/m4gi/src/routes.jsx
+++ b/frontend/m4gi/src/routes.jsx
@@ -1,6 +1,7 @@
 import MainCampSearchPage from "./pages/Main/Main_CampSearchPage";
 import MainCampSearchResultPage from "./pages/Main/Main_CampSearchResultPage";
 import CampDetailPage from "./pages/Indev/CampDetailPage";
+import CampZoneDetailPage from "./pages/Indev/CampZoneDetailPage";
 import ReservationDashboard from "./pages/CampStaff/ReservationDashboardPage";
 import AdminUserList from "./components/Admin/UI/Admin_UserList";
 import AdminSidebar from './components/Admin/UI/Admin_Sidebar';
@@ -22,6 +23,7 @@ const routeList = [
   { path: '/search', element: <MainCampSearchPage /> },
   { path: '/searchResult', element: <MainCampSearchResultPage /> },
   { path: '/detail/:campgroundId', element: <CampDetailPage/>},
+  { path: '/detail/:campgroundId/:zoneId', element: <CampZoneDetailPage/>},
   { path: '/reservationDashboard', element: <ReservationDashboard/>},
    
   //404 fallback

--- a/workspace_project/Project/src/main/java/com/m4gi/controller/CampgroundController.java
+++ b/workspace_project/Project/src/main/java/com/m4gi/controller/CampgroundController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.*;
 
 import com.m4gi.dto.CampgroundCardDTO;
 import com.m4gi.dto.CampgroundSearchDTO;
+import com.m4gi.dto.CampgroundZoneDetailDTO;
 import com.m4gi.service.CampgroundService;
 
 import lombok.RequiredArgsConstructor;
@@ -68,4 +69,21 @@ public class CampgroundController {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND); // 해당 ID의 캠핑장이 없거나 데이터 조합 실패 시 404 반환
         }
     }
+    
+	// 캠핑장 구역 상세 페이지 - 구역 및 사이트 정보 가져오기
+    @GetMapping("/{campgroundId}/zones/{zoneId}")
+    public ResponseEntity<CampgroundZoneDetailDTO> getZoneDetail(@PathVariable String zoneId, @PathVariable String campgroundId) {
+    	System.out.println("✅ 요청 도착: " + campgroundId + ", " + zoneId);
+    	
+    	CampgroundZoneDetailDTO detail = campgroundService.getZoneDetail(zoneId);
+    	
+    	System.out.println("✅ 반환할 detail: " + detail);
+    	if (detail == null) {
+    		return ResponseEntity.notFound().build();
+    	}
+    	return ResponseEntity.ok(detail);
+    }
+    
+    
+    
 }

--- a/workspace_project/Project/src/main/java/com/m4gi/controller/CampgroundController.java
+++ b/workspace_project/Project/src/main/java/com/m4gi/controller/CampgroundController.java
@@ -82,6 +82,16 @@ public class CampgroundController {
     	return ResponseEntity.ok(detail);
     }
     
-    
+    // 캠핑장 구역 상세 페이지 - 구역 및 사이트 정보 가져오기
+    @GetMapping("/{campgroundId}/mapImage")
+    public ResponseEntity<String> getCampgroundMapImage(@PathVariable String campgroundId) {
+    	String mapImageURL = campgroundService.getCampgroundMapImage(campgroundId);
+    	
+    	if(mapImageURL != null) {
+    		return ResponseEntity.ok(mapImageURL);
+    	} else {
+    		return ResponseEntity.notFound().build();
+    	}
+    }
     
 }

--- a/workspace_project/Project/src/main/java/com/m4gi/controller/CampgroundController.java
+++ b/workspace_project/Project/src/main/java/com/m4gi/controller/CampgroundController.java
@@ -1,17 +1,14 @@
 package com.m4gi.controller;
 
-import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import com.m4gi.dto.CampgroundCardDTO;
 import com.m4gi.dto.CampgroundSearchDTO;
-import com.m4gi.dto.CampgroundZoneDetailDTO;
 import com.m4gi.service.CampgroundService;
 
 import lombok.RequiredArgsConstructor;
@@ -70,20 +67,8 @@ public class CampgroundController {
         }
     }
     
-	// 캠핑장 구역 상세 페이지 - 구역 및 사이트 정보 가져오기
-    @GetMapping("/{campgroundId}/zones/{zoneId}")
-    public ResponseEntity<CampgroundZoneDetailDTO> getZoneDetail(@PathVariable String zoneId, @PathVariable String campgroundId) {
-    	
-    	CampgroundZoneDetailDTO detail = campgroundService.getZoneDetail(zoneId);
-    	
-    	if (detail == null) {
-    		return ResponseEntity.notFound().build();
-    	}
-    	return ResponseEntity.ok(detail);
-    }
-    
-    // 캠핑장 구역 상세 페이지 - 구역 및 사이트 정보 가져오기
-    @GetMapping("/{campgroundId}/mapImage")
+    // 캠핑장 지도 이미지 가져오기 - 구역 상세 페이지
+    @GetMapping("/{campgroundId}/map-image")
     public ResponseEntity<String> getCampgroundMapImage(@PathVariable String campgroundId) {
     	String mapImageURL = campgroundService.getCampgroundMapImage(campgroundId);
     	
@@ -93,5 +78,4 @@ public class CampgroundController {
     		return ResponseEntity.notFound().build();
     	}
     }
-    
 }

--- a/workspace_project/Project/src/main/java/com/m4gi/controller/CampgroundController.java
+++ b/workspace_project/Project/src/main/java/com/m4gi/controller/CampgroundController.java
@@ -73,11 +73,9 @@ public class CampgroundController {
 	// 캠핑장 구역 상세 페이지 - 구역 및 사이트 정보 가져오기
     @GetMapping("/{campgroundId}/zones/{zoneId}")
     public ResponseEntity<CampgroundZoneDetailDTO> getZoneDetail(@PathVariable String zoneId, @PathVariable String campgroundId) {
-    	System.out.println("✅ 요청 도착: " + campgroundId + ", " + zoneId);
     	
     	CampgroundZoneDetailDTO detail = campgroundService.getZoneDetail(zoneId);
     	
-    	System.out.println("✅ 반환할 detail: " + detail);
     	if (detail == null) {
     		return ResponseEntity.notFound().build();
     	}

--- a/workspace_project/Project/src/main/java/com/m4gi/controller/CampgroundController.java
+++ b/workspace_project/Project/src/main/java/com/m4gi/controller/CampgroundController.java
@@ -9,7 +9,9 @@ import org.springframework.web.bind.annotation.*;
 
 import com.m4gi.dto.CampgroundCardDTO;
 import com.m4gi.dto.CampgroundSearchDTO;
+import com.m4gi.dto.CampgroundZoneDetailDTO;
 import com.m4gi.service.CampgroundService;
+import com.m4gi.service.CampgroundZoneService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -17,7 +19,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @RequestMapping("/api/campgrounds")
 public class CampgroundController {
+	
 	private final CampgroundService campgroundService;
+	private final CampgroundZoneService zoneService;
 	
 	// 캠핑장 검색 목록 조회
 	@GetMapping("/searchResult")
@@ -67,7 +71,7 @@ public class CampgroundController {
         }
     }
     
-    // 캠핑장 지도 이미지 가져오기 - 구역 상세 페이지
+    // 캠핑장 구역 상세 페이지 - 캠핑장 지도 이미지 가져오기
     @GetMapping("/{campgroundId}/map-image")
     public ResponseEntity<String> getCampgroundMapImage(@PathVariable String campgroundId) {
     	String mapImageURL = campgroundService.getCampgroundMapImage(campgroundId);
@@ -77,5 +81,20 @@ public class CampgroundController {
     	} else {
     		return ResponseEntity.notFound().build();
     	}
+    }
+    
+	// 캠핑장 구역 상세 페이지 - 구역 및 사이트 정보 가져오기
+    @GetMapping("/{campgroundId}/zones/{zoneId}")
+    public ResponseEntity<CampgroundZoneDetailDTO> getZoneDetail(
+    		@PathVariable String campgroundId,
+    		@PathVariable String zoneId
+    		) {
+    	
+    	CampgroundZoneDetailDTO detail = zoneService.getZoneDetail(campgroundId, zoneId);
+    	
+    	if (detail == null) {
+    		return ResponseEntity.notFound().build();
+    	}
+    	return ResponseEntity.ok(detail);
     }
 }

--- a/workspace_project/Project/src/main/java/com/m4gi/controller/CampgroundZoneController.java
+++ b/workspace_project/Project/src/main/java/com/m4gi/controller/CampgroundZoneController.java
@@ -1,0 +1,49 @@
+package com.m4gi.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.m4gi.dto.CampgroundZoneDetailDTO;
+import com.m4gi.service.CampgroundService;
+import com.m4gi.service.CampgroundZoneService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/zones")
+public class CampgroundZoneController {
+	
+	private final CampgroundZoneService zoneService;
+	
+	// 구역 및 사이트 정보 가져오기
+    @GetMapping("/{zoneId}")
+    public ResponseEntity<CampgroundZoneDetailDTO> getZoneDetail(@PathVariable String zoneId) {
+    	
+    	CampgroundZoneDetailDTO detail = zoneService.getZoneDetail(zoneId);
+    	
+    	if (detail == null) {
+    		return ResponseEntity.notFound().build();
+    	}
+    	return ResponseEntity.ok(detail);
+    }
+    
+    // 예약 가능한 사이트 가져오기
+    @GetMapping("/{zoneId}/available-sites")
+    public List<String> getAvailableSites(
+    		@RequestParam String zoneId,
+    		@RequestParam String startDate,
+    		@RequestParam String endDate
+    		) {
+    	return zoneService.getAvailableSitesByZoneId(zoneId, startDate, endDate);
+    }
+	
+	
+	
+}

--- a/workspace_project/Project/src/main/java/com/m4gi/controller/CampgroundZoneController.java
+++ b/workspace_project/Project/src/main/java/com/m4gi/controller/CampgroundZoneController.java
@@ -20,18 +20,6 @@ import lombok.RequiredArgsConstructor;
 public class CampgroundZoneController {
 	
 	private final CampgroundZoneService zoneService;
-	
-	// 구역 및 사이트 정보 가져오기
-    @GetMapping("/{zoneId}")
-    public ResponseEntity<CampgroundZoneDetailDTO> getZoneDetail(@PathVariable String zoneId) {
-    	
-    	CampgroundZoneDetailDTO detail = zoneService.getZoneDetail(zoneId);
-    	
-    	if (detail == null) {
-    		return ResponseEntity.notFound().build();
-    	}
-    	return ResponseEntity.ok(detail);
-    }
     
     // 예약 가능한 사이트 가져오기
     @GetMapping("/{zoneId}/available-sites")

--- a/workspace_project/Project/src/main/java/com/m4gi/controller/CampgroundZoneController.java
+++ b/workspace_project/Project/src/main/java/com/m4gi/controller/CampgroundZoneController.java
@@ -10,7 +10,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.m4gi.dto.CampgroundZoneDetailDTO;
-import com.m4gi.service.CampgroundService;
 import com.m4gi.service.CampgroundZoneService;
 
 import lombok.RequiredArgsConstructor;
@@ -37,7 +36,7 @@ public class CampgroundZoneController {
     // 예약 가능한 사이트 가져오기
     @GetMapping("/{zoneId}/available-sites")
     public List<String> getAvailableSites(
-    		@RequestParam String zoneId,
+    		@PathVariable  String zoneId,
     		@RequestParam String startDate,
     		@RequestParam String endDate
     		) {

--- a/workspace_project/Project/src/main/java/com/m4gi/dto/CampgroundSiteDTO.java
+++ b/workspace_project/Project/src/main/java/com/m4gi/dto/CampgroundSiteDTO.java
@@ -9,4 +9,5 @@ public class CampgroundSiteDTO {
     private float widthMeters;
     private float heightMeters;
     private int capacity;
+    private int isActive;
 }

--- a/workspace_project/Project/src/main/java/com/m4gi/dto/CampgroundSiteDTO.java
+++ b/workspace_project/Project/src/main/java/com/m4gi/dto/CampgroundSiteDTO.java
@@ -1,0 +1,12 @@
+package com.m4gi.dto;
+
+import lombok.Data;
+
+@Data
+public class CampgroundSiteDTO {
+	private String siteId;
+    private String siteName;
+    private float widthMeters;
+    private float heightMeters;
+    private int capacity;
+}

--- a/workspace_project/Project/src/main/java/com/m4gi/dto/CampgroundZoneDetailDTO.java
+++ b/workspace_project/Project/src/main/java/com/m4gi/dto/CampgroundZoneDetailDTO.java
@@ -1,0 +1,19 @@
+package com.m4gi.dto;
+
+import java.util.List;
+
+import lombok.Data;
+
+@Data
+public class CampgroundZoneDetailDTO {
+	private String zoneId;
+	private String zoneName;
+    private String zoneType;
+    private String zoneTerrainType;
+    private int capacity;
+    private String description;
+    
+    private List<CampgroundSiteDTO> sites;
+
+    private List<ReviewDTO> reviews;
+}

--- a/workspace_project/Project/src/main/java/com/m4gi/dto/CampgroundZoneDetailDTO.java
+++ b/workspace_project/Project/src/main/java/com/m4gi/dto/CampgroundZoneDetailDTO.java
@@ -12,6 +12,7 @@ public class CampgroundZoneDetailDTO {
     private String zoneTerrainType;
     private int capacity;
     private String description;
+    private String zoneImage; // JSON 전체 문자열 저장됨
     
     private List<CampgroundSiteDTO> sites;
 

--- a/workspace_project/Project/src/main/java/com/m4gi/dto/ReviewDTO.java
+++ b/workspace_project/Project/src/main/java/com/m4gi/dto/ReviewDTO.java
@@ -12,6 +12,7 @@ public class ReviewDTO {
     private String providerUserId;      // 리뷰 작성자 사용자 ID
     private String campgroundId;        // 캠핑장 ID (필터링용)
     private String reservationId;       // 예약 ID (중복 리뷰 체크용)
+    private String siteName;			// 사이트명 - 캠핑장 구역용
     private int reviewRating;           // 별점 점수 (예: 1~5)
     private String reviewContent;       // 리뷰 내용
     private String reviewPhotosJson;    // 리뷰 사진 URL JSON 문자열

--- a/workspace_project/Project/src/main/java/com/m4gi/mapper/CampgroundMapper.java
+++ b/workspace_project/Project/src/main/java/com/m4gi/mapper/CampgroundMapper.java
@@ -24,10 +24,6 @@ public interface CampgroundMapper {
 	Map<String, Object> getCampgroundDetail(String campgroundId); // 이 메서드가 두 매퍼를 호출하고 결과를 조합
 	
 	// 캠핑장 구역 상세 페이지
-	CampgroundZoneDetailDTO selectZoneDetailByZoneId(String zoneId);
-	List<CampgroundSiteDTO> selectSitesDetailByZoneId(String zoneId);
 	String selectCampgroundMapImage(@Param("campgroundId") String campgroundId);
-	List<ReviewDTO> selectReviewsByZoneId(String zoneId);
-	
 	
 }

--- a/workspace_project/Project/src/main/java/com/m4gi/mapper/CampgroundMapper.java
+++ b/workspace_project/Project/src/main/java/com/m4gi/mapper/CampgroundMapper.java
@@ -17,14 +17,17 @@ public interface CampgroundMapper {
 	
 	// 캠핑장 검색 목록 조회
 	List<CampgroundCardDTO> selectSearchedCampgrounds(CampgroundSearchDTO dto);
-
+	
+	// 캠핑장 상세 페이지
 	Map<String, Object> selectCampgroundById(@Param("campgroundId") String campgroundId);
 	List<Map<String, Object>> selectReviewById(@Param("campgroundId") String campgroundId);
 	Map<String, Object> getCampgroundDetail(String campgroundId); // 이 메서드가 두 매퍼를 호출하고 결과를 조합
 	
-	// 캠핑장 구역 상세 페이지 - 구역 및 사이트 정보 가져오기
+	// 캠핑장 구역 상세 페이지
 	CampgroundZoneDetailDTO selectZoneDetailByZoneId(String zoneId);
 	List<CampgroundSiteDTO> selectSitesDetailByZoneId(String zoneId);
+	String selectCampgroundMapImage(@Param("campgroundId") String campgroundId);
 	List<ReviewDTO> selectReviewsByZoneId(String zoneId);
+	
 	
 }

--- a/workspace_project/Project/src/main/java/com/m4gi/mapper/CampgroundMapper.java
+++ b/workspace_project/Project/src/main/java/com/m4gi/mapper/CampgroundMapper.java
@@ -1,6 +1,5 @@
 package com.m4gi.mapper;
 
-import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 
@@ -9,6 +8,9 @@ import org.apache.ibatis.annotations.Param;
 
 import com.m4gi.dto.CampgroundCardDTO;
 import com.m4gi.dto.CampgroundSearchDTO;
+import com.m4gi.dto.CampgroundSiteDTO;
+import com.m4gi.dto.CampgroundZoneDetailDTO;
+import com.m4gi.dto.ReviewDTO;
 
 @Mapper
 public interface CampgroundMapper {
@@ -19,4 +21,10 @@ public interface CampgroundMapper {
 	Map<String, Object> selectCampgroundById(@Param("campgroundId") String campgroundId);
 	List<Map<String, Object>> selectReviewById(@Param("campgroundId") String campgroundId);
 	Map<String, Object> getCampgroundDetail(String campgroundId); // 이 메서드가 두 매퍼를 호출하고 결과를 조합
+	
+	// 캠핑장 구역 상세 페이지 - 구역 및 사이트 정보 가져오기
+	CampgroundZoneDetailDTO selectZoneDetailByZoneId(String zoneId);
+	List<CampgroundSiteDTO> selectSitesDetailByZoneId(String zoneId);
+	List<ReviewDTO> selectReviewsByZoneId(String zoneId);
+	
 }

--- a/workspace_project/Project/src/main/java/com/m4gi/mapper/CampgroundZoneMapper.java
+++ b/workspace_project/Project/src/main/java/com/m4gi/mapper/CampgroundZoneMapper.java
@@ -14,7 +14,7 @@ import com.m4gi.dto.ReviewDTO;
 public interface CampgroundZoneMapper {
 	
 	// 캠핑장 구역 상세 페이지
-	CampgroundZoneDetailDTO selectZoneDetailByZoneId(String zoneId);
+	CampgroundZoneDetailDTO selectZoneDetailByZoneId(Map<String, Object> params);
 	List<CampgroundSiteDTO> selectSitesDetailByZoneId(String zoneId);
 	String selectCampgroundMapImage(@Param("campgroundId") String campgroundId);
 	List<ReviewDTO> selectReviewsByZoneId(String zoneId);

--- a/workspace_project/Project/src/main/java/com/m4gi/mapper/CampgroundZoneMapper.java
+++ b/workspace_project/Project/src/main/java/com/m4gi/mapper/CampgroundZoneMapper.java
@@ -1,0 +1,23 @@
+package com.m4gi.mapper;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import com.m4gi.dto.CampgroundSiteDTO;
+import com.m4gi.dto.CampgroundZoneDetailDTO;
+import com.m4gi.dto.ReviewDTO;
+
+@Mapper
+public interface CampgroundZoneMapper {
+	
+	// 캠핑장 구역 상세 페이지
+	CampgroundZoneDetailDTO selectZoneDetailByZoneId(String zoneId);
+	List<CampgroundSiteDTO> selectSitesDetailByZoneId(String zoneId);
+	String selectCampgroundMapImage(@Param("campgroundId") String campgroundId);
+	List<ReviewDTO> selectReviewsByZoneId(String zoneId);
+	List<String> selectAvailableSitesByZoneId(Map<String, Object> params);
+	
+}

--- a/workspace_project/Project/src/main/java/com/m4gi/service/CampgroundService.java
+++ b/workspace_project/Project/src/main/java/com/m4gi/service/CampgroundService.java
@@ -21,4 +21,6 @@ public interface CampgroundService {
 	// 캠핑장 구역 상세 페이지 - 구역 및 사이트 정보 가져오기
 	CampgroundZoneDetailDTO getZoneDetail(String zoneId);
 	
+	// 캠핑장 구역 상세 페이지 - 캠핑장 지도 url 가져오기
+	String getCampgroundMapImage(String campgroundId);
 }

--- a/workspace_project/Project/src/main/java/com/m4gi/service/CampgroundService.java
+++ b/workspace_project/Project/src/main/java/com/m4gi/service/CampgroundService.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 import com.m4gi.dto.CampgroundCardDTO;
 import com.m4gi.dto.CampgroundSearchDTO;
+import com.m4gi.dto.CampgroundSiteDTO;
 import com.m4gi.dto.CampgroundZoneDetailDTO;
 
 public interface CampgroundService {
@@ -17,10 +18,7 @@ public interface CampgroundService {
 
 	// ✨ 통합된 캠핑장 상세 정보를 조회하는 메서드 추가
 	Map<String, Object> getCampgroundDetail(String campgroundId); // 이 메서드가 두 매퍼를 호출하고 결과를 조합
-
-	// 캠핑장 구역 상세 페이지 - 구역 및 사이트 정보 가져오기
-	CampgroundZoneDetailDTO getZoneDetail(String zoneId);
 	
-	// 캠핑장 구역 상세 페이지 - 캠핑장 지도 url 가져오기
+	// 캠핑장 지도 url 가져오기 - 캠핑장 구역 상세 페이지
 	String getCampgroundMapImage(String campgroundId);
 }

--- a/workspace_project/Project/src/main/java/com/m4gi/service/CampgroundService.java
+++ b/workspace_project/Project/src/main/java/com/m4gi/service/CampgroundService.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 import com.m4gi.dto.CampgroundCardDTO;
 import com.m4gi.dto.CampgroundSearchDTO;
+import com.m4gi.dto.CampgroundZoneDetailDTO;
 
 public interface CampgroundService {
 	
@@ -16,4 +17,8 @@ public interface CampgroundService {
 
 	// ✨ 통합된 캠핑장 상세 정보를 조회하는 메서드 추가
 	Map<String, Object> getCampgroundDetail(String campgroundId); // 이 메서드가 두 매퍼를 호출하고 결과를 조합
+
+	// 캠핑장 구역 상세 페이지 - 구역 및 사이트 정보 가져오기
+	CampgroundZoneDetailDTO getZoneDetail(String zoneId);
+	
 }

--- a/workspace_project/Project/src/main/java/com/m4gi/service/CampgroundServiceImpl.java
+++ b/workspace_project/Project/src/main/java/com/m4gi/service/CampgroundServiceImpl.java
@@ -9,6 +9,9 @@ import org.springframework.stereotype.Service;
 
 import com.m4gi.dto.CampgroundCardDTO;
 import com.m4gi.dto.CampgroundSearchDTO;
+import com.m4gi.dto.CampgroundSiteDTO;
+import com.m4gi.dto.CampgroundZoneDetailDTO;
+import com.m4gi.dto.ReviewDTO;
 import com.m4gi.mapper.CampgroundMapper;
 
 import lombok.RequiredArgsConstructor;
@@ -72,4 +75,20 @@ public class CampgroundServiceImpl implements CampgroundService{
 		return Response;
 	}
 	
+	// 캠핑장 구역 상세 페이지 - 구역 및 사이트 정보 가져오기
+	@Override
+	public CampgroundZoneDetailDTO getZoneDetail(String zoneId) {
+		CampgroundZoneDetailDTO zoneDetail = campgroundMapper.selectZoneDetailByZoneId(zoneId);
+		if(zoneDetail == null) {
+			return null;
+		}
+		
+		List<CampgroundSiteDTO> sites = campgroundMapper.selectSitesDetailByZoneId(zoneId);
+		zoneDetail.setSites(sites);
+		
+		List<ReviewDTO> reviews = campgroundMapper.selectReviewsByZoneId(zoneId);
+		zoneDetail.setReviews(reviews);
+		
+		return zoneDetail;
+	}
 }

--- a/workspace_project/Project/src/main/java/com/m4gi/service/CampgroundServiceImpl.java
+++ b/workspace_project/Project/src/main/java/com/m4gi/service/CampgroundServiceImpl.java
@@ -91,4 +91,10 @@ public class CampgroundServiceImpl implements CampgroundService{
 		
 		return zoneDetail;
 	}
+	
+	// 캠핑장 구역 상세 페이지 - 캠핑장 지도 url 가져오기
+	@Override
+	public String getCampgroundMapImage(String campgroundId) {
+		return campgroundMapper.selectCampgroundMapImage(campgroundId);
+	}
 }

--- a/workspace_project/Project/src/main/java/com/m4gi/service/CampgroundServiceImpl.java
+++ b/workspace_project/Project/src/main/java/com/m4gi/service/CampgroundServiceImpl.java
@@ -75,23 +75,6 @@ public class CampgroundServiceImpl implements CampgroundService{
 		return Response;
 	}
 	
-	// 캠핑장 구역 상세 페이지 - 구역 및 사이트 정보 가져오기
-	@Override
-	public CampgroundZoneDetailDTO getZoneDetail(String zoneId) {
-		CampgroundZoneDetailDTO zoneDetail = campgroundMapper.selectZoneDetailByZoneId(zoneId);
-		if(zoneDetail == null) {
-			return null;
-		}
-		
-		List<CampgroundSiteDTO> sites = campgroundMapper.selectSitesDetailByZoneId(zoneId);
-		zoneDetail.setSites(sites);
-		
-		List<ReviewDTO> reviews = campgroundMapper.selectReviewsByZoneId(zoneId);
-		zoneDetail.setReviews(reviews);
-		
-		return zoneDetail;
-	}
-	
 	// 캠핑장 구역 상세 페이지 - 캠핑장 지도 url 가져오기
 	@Override
 	public String getCampgroundMapImage(String campgroundId) {

--- a/workspace_project/Project/src/main/java/com/m4gi/service/CampgroundZoneService.java
+++ b/workspace_project/Project/src/main/java/com/m4gi/service/CampgroundZoneService.java
@@ -1,0 +1,13 @@
+package com.m4gi.service;
+
+import java.util.List;
+
+import com.m4gi.dto.CampgroundZoneDetailDTO;
+
+public interface CampgroundZoneService {
+	// 캠핑장 구역 상세 페이지 - 구역 및 사이트 정보 가져오기
+	CampgroundZoneDetailDTO getZoneDetail(String zoneId);
+	
+	// 캠핑장 구역 상세 페이지 - 예약 가능한 사이트 가져오기
+	List<String> getAvailableSitesByZoneId(String zoneId, String startDate, String endDate);
+}

--- a/workspace_project/Project/src/main/java/com/m4gi/service/CampgroundZoneService.java
+++ b/workspace_project/Project/src/main/java/com/m4gi/service/CampgroundZoneService.java
@@ -6,7 +6,7 @@ import com.m4gi.dto.CampgroundZoneDetailDTO;
 
 public interface CampgroundZoneService {
 	// 캠핑장 구역 상세 페이지 - 구역 및 사이트 정보 가져오기
-	CampgroundZoneDetailDTO getZoneDetail(String zoneId);
+	CampgroundZoneDetailDTO getZoneDetail(String campgroundId, String zoneId);
 	
 	// 캠핑장 구역 상세 페이지 - 예약 가능한 사이트 가져오기
 	List<String> getAvailableSitesByZoneId(String zoneId, String startDate, String endDate);

--- a/workspace_project/Project/src/main/java/com/m4gi/service/CampgroundZoneServiceImpl.java
+++ b/workspace_project/Project/src/main/java/com/m4gi/service/CampgroundZoneServiceImpl.java
@@ -1,0 +1,50 @@
+package com.m4gi.service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+
+import com.m4gi.dto.CampgroundSiteDTO;
+import com.m4gi.dto.CampgroundZoneDetailDTO;
+import com.m4gi.dto.ReviewDTO;
+import com.m4gi.mapper.CampgroundZoneMapper;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CampgroundZoneServiceImpl implements CampgroundZoneService {
+	
+	private final CampgroundZoneMapper campgroundZoneMapper;
+	
+	// 캠핑장 구역 상세 페이지 - 구역 및 사이트 정보 가져오기
+	@Override
+	public CampgroundZoneDetailDTO getZoneDetail(String zoneId) {
+		CampgroundZoneDetailDTO zoneDetail = campgroundZoneMapper.selectZoneDetailByZoneId(zoneId);
+		if(zoneDetail == null) {
+			return null;
+		}
+		
+		List<CampgroundSiteDTO> sites = campgroundZoneMapper.selectSitesDetailByZoneId(zoneId);
+		zoneDetail.setSites(sites);
+		
+		List<ReviewDTO> reviews = campgroundZoneMapper.selectReviewsByZoneId(zoneId);
+		zoneDetail.setReviews(reviews);
+		
+		return zoneDetail;
+	}
+	
+	// 캠핑장 구역 상세 페이지 - 예약 가능한 사이트 가져오기
+	@Override
+	public List<String> getAvailableSitesByZoneId(String zoneId, String startDate, String endDate) {
+		Map<String, Object> params = new HashMap<>();
+		params.put("zoneId", zoneId);
+		params.put("startDate", startDate);
+		params.put("endDate", endDate);
+		
+		return campgroundZoneMapper.selectAvailableSitesByZoneId(params);
+	}
+	
+}

--- a/workspace_project/Project/src/main/java/com/m4gi/service/CampgroundZoneServiceImpl.java
+++ b/workspace_project/Project/src/main/java/com/m4gi/service/CampgroundZoneServiceImpl.java
@@ -22,8 +22,12 @@ public class CampgroundZoneServiceImpl implements CampgroundZoneService {
 	
 	// 캠핑장 구역 상세 페이지 - 구역 및 사이트 정보 가져오기
 	@Override
-	public CampgroundZoneDetailDTO getZoneDetail(String zoneId) {
-		CampgroundZoneDetailDTO zoneDetail = campgroundZoneMapper.selectZoneDetailByZoneId(zoneId);
+	public CampgroundZoneDetailDTO getZoneDetail(String campgroundId, String zoneId) {
+		Map<String, Object> params = new HashMap<>();
+		params.put("campgroundId", campgroundId);
+		params.put("zoneId", zoneId);
+		
+		CampgroundZoneDetailDTO zoneDetail = campgroundZoneMapper.selectZoneDetailByZoneId(params);
 		if(zoneDetail == null) {
 			return null;
 		}

--- a/workspace_project/Project/src/main/java/com/m4gi/service/CampgroundZoneServiceImpl.java
+++ b/workspace_project/Project/src/main/java/com/m4gi/service/CampgroundZoneServiceImpl.java
@@ -1,5 +1,6 @@
 package com.m4gi.service;
 
+import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -41,8 +42,8 @@ public class CampgroundZoneServiceImpl implements CampgroundZoneService {
 	public List<String> getAvailableSitesByZoneId(String zoneId, String startDate, String endDate) {
 		Map<String, Object> params = new HashMap<>();
 		params.put("zoneId", zoneId);
-		params.put("startDate", startDate);
-		params.put("endDate", endDate);
+		params.put("startDate", LocalDate.parse(startDate));
+		params.put("endDate", LocalDate.parse(endDate));
 		
 		return campgroundZoneMapper.selectAvailableSitesByZoneId(params);
 	}

--- a/workspace_project/Project/src/main/resources/mapper/CampgroundMapper.xml
+++ b/workspace_project/Project/src/main/resources/mapper/CampgroundMapper.xml
@@ -164,9 +164,10 @@
 			zone_id, 
 			zone_name, 
 			zone_type, 
-			zone_terrain_type, 
+			zone_terrain_type,
 			capacity, 
-			description
+			description,
+			zone_image
 		FROM campground_zones
 		WHERE zone_id = #{zoneId}
 		AND is_active = TRUE

--- a/workspace_project/Project/src/main/resources/mapper/CampgroundMapper.xml
+++ b/workspace_project/Project/src/main/resources/mapper/CampgroundMapper.xml
@@ -135,7 +135,6 @@
 	    <result property="campgroundType" column="campgroundTypeString" typeHandler="com.m4gi.handler.CsvSetTypeHandler"/>
 	    <result property="campgroundImage" column="campgroundImage"/>
 	</resultMap>
-	<!-- 캠핑장 목록 조회 -->
 
 	<!-- 상세 페이지 -->
 	<select id="selectCampgroundById" parameterType="java.lang.String" resultType="java.util.Map">
@@ -158,4 +157,52 @@
 		WHERE
 			r.campground_id = #{campgroundId};
 	</select>
+	
+	<!-- 캠핑장 구역 상세 페이지 - 구역 및 사이트 정보 가져오기 -->
+	<select id="selectZoneDetailByZoneId" parameterType="java.lang.String" resultType="com.m4gi.dto.CampgroundZoneDetailDTO">
+		SELECT 
+			zone_id, 
+			zone_name, 
+			zone_type, 
+			zone_terrain_type, 
+			capacity, 
+			description
+		FROM campground_zones
+		WHERE zone_id = #{zoneId}
+		AND is_active = TRUE
+	</select>
+	
+	<select id="selectSitesDetailByZoneId" parameterType="java.lang.String" resultType="com.m4gi.dto.CampgroundSiteDTO">
+		SELECT 
+			site_id, 
+			site_name, 
+			width_meters, 
+			height_meters, 
+			capacity
+		FROM campground_sites
+		WHERE zone_id = #{zoneId}
+		AND is_active = TRUE
+	</select>
+	
+	<select id="selectReviewsByZoneId" parameterType="java.lang.String" resultType="com.m4gi.dto.ReviewDTO">
+		SELECT
+			r.review_id,
+	        r.provider_code,
+	        r.provider_user_id,
+	        r.reservation_id,
+	        r.review_rating,
+	        r.review_content,
+	        r.review_photos AS reviewPhotosJson,
+	        r.created_at,
+	        r.updated_at,
+	        rv.checkin_time AS checkInTime,
+	        rv.checkout_time AS checkOutTime
+        FROM campground_zones cz
+        JOIN campground_sites cs ON cs.zone_id = cz.zone_id
+        JOIN reservations rv ON cs.site_id = rv.reservation_site
+        JOIN reviews r ON rv.reservation_id = r.reservation_id
+        WHERE cz.zone_id = #{zoneId}
+	</select>
+		
+	
 </mapper>

--- a/workspace_project/Project/src/main/resources/mapper/CampgroundMapper.xml
+++ b/workspace_project/Project/src/main/resources/mapper/CampgroundMapper.xml
@@ -158,7 +158,7 @@
 			r.campground_id = #{campgroundId};
 	</select>
 	
-	<!-- 캠핑장 구역 상세 페이지 - 구역 및 사이트 정보 가져오기 -->
+	<!-- 캠핑장 구역 상세 페이지 -->
 	<select id="selectZoneDetailByZoneId" parameterType="java.lang.String" resultType="com.m4gi.dto.CampgroundZoneDetailDTO">
 		SELECT 
 			zone_id, 
@@ -179,10 +179,17 @@
 			site_name, 
 			width_meters, 
 			height_meters, 
-			capacity
+			capacity,
+			is_active
 		FROM campground_sites
 		WHERE zone_id = #{zoneId}
 		AND is_active = TRUE
+	</select>
+
+	<select id="selectCampgroundMapImage" parameterType="java.lang.String" resultType="java.lang.String">
+	  SELECT JSON_UNQUOTE(JSON_EXTRACT(campground_image, '$.map[0]'))
+	  FROM campgrounds
+	  WHERE campground_id = #{campgroundId}
 	</select>
 	
 	<select id="selectReviewsByZoneId" parameterType="java.lang.String" resultType="com.m4gi.dto.ReviewDTO">
@@ -197,13 +204,14 @@
 	        r.created_at,
 	        r.updated_at,
 	        rv.checkin_time AS checkInTime,
-	        rv.checkout_time AS checkOutTime
+	        rv.checkout_time AS checkOutTime,
+	        cs.site_name
         FROM campground_zones cz
         JOIN campground_sites cs ON cs.zone_id = cz.zone_id
         JOIN reservations rv ON cs.site_id = rv.reservation_site
         JOIN reviews r ON rv.reservation_id = r.reservation_id
         WHERE cz.zone_id = #{zoneId}
 	</select>
-		
+	
 	
 </mapper>

--- a/workspace_project/Project/src/main/resources/mapper/CampgroundMapper.xml
+++ b/workspace_project/Project/src/main/resources/mapper/CampgroundMapper.xml
@@ -159,58 +159,10 @@
 	</select>
 	
 	<!-- 캠핑장 구역 상세 페이지 -->
-	<select id="selectZoneDetailByZoneId" parameterType="java.lang.String" resultType="com.m4gi.dto.CampgroundZoneDetailDTO">
-		SELECT 
-			zone_id, 
-			zone_name, 
-			zone_type, 
-			zone_terrain_type,
-			capacity, 
-			description,
-			zone_image
-		FROM campground_zones
-		WHERE zone_id = #{zoneId}
-		AND is_active = TRUE
-	</select>
-	
-	<select id="selectSitesDetailByZoneId" parameterType="java.lang.String" resultType="com.m4gi.dto.CampgroundSiteDTO">
-		SELECT 
-			site_id, 
-			site_name, 
-			width_meters, 
-			height_meters, 
-			capacity,
-			is_active
-		FROM campground_sites
-		WHERE zone_id = #{zoneId}
-		AND is_active = TRUE
-	</select>
-
 	<select id="selectCampgroundMapImage" parameterType="java.lang.String" resultType="java.lang.String">
 	  SELECT JSON_UNQUOTE(JSON_EXTRACT(campground_image, '$.map[0]'))
 	  FROM campgrounds
 	  WHERE campground_id = #{campgroundId}
-	</select>
-	
-	<select id="selectReviewsByZoneId" parameterType="java.lang.String" resultType="com.m4gi.dto.ReviewDTO">
-		SELECT
-			r.review_id,
-	        r.provider_code,
-	        r.provider_user_id,
-	        r.reservation_id,
-	        r.review_rating,
-	        r.review_content,
-	        r.review_photos AS reviewPhotosJson,
-	        r.created_at,
-	        r.updated_at,
-	        rv.checkin_time AS checkInTime,
-	        rv.checkout_time AS checkOutTime,
-	        cs.site_name
-        FROM campground_zones cz
-        JOIN campground_sites cs ON cs.zone_id = cz.zone_id
-        JOIN reservations rv ON cs.site_id = rv.reservation_site
-        JOIN reviews r ON rv.reservation_id = r.reservation_id
-        WHERE cz.zone_id = #{zoneId}
 	</select>
 	
 	

--- a/workspace_project/Project/src/main/resources/mapper/CampgroundZoneMapper.xml
+++ b/workspace_project/Project/src/main/resources/mapper/CampgroundZoneMapper.xml
@@ -6,7 +6,7 @@
 <mapper namespace="com.m4gi.mapper.CampgroundZoneMapper">
 
 	<!-- 캠핑장 구역 상세 페이지 -->
-	<select id="selectZoneDetailByZoneId" parameterType="java.lang.String" resultType="com.m4gi.dto.CampgroundZoneDetailDTO">
+	<select id="selectZoneDetailByZoneId" parameterType="map" resultType="com.m4gi.dto.CampgroundZoneDetailDTO">
 		SELECT 
 			zone_id, 
 			zone_name, 
@@ -17,6 +17,7 @@
 			zone_image
 		FROM campground_zones
 		WHERE zone_id = #{zoneId}
+		AND campground_id = #{campgroundId}
 		AND is_active = TRUE
 	</select>
 	

--- a/workspace_project/Project/src/main/resources/mapper/CampgroundZoneMapper.xml
+++ b/workspace_project/Project/src/main/resources/mapper/CampgroundZoneMapper.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+	PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+	"http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.m4gi.mapper.CampgroundZoneMapper">
+
+	<!-- 캠핑장 구역 상세 페이지 -->
+	<select id="selectZoneDetailByZoneId" parameterType="java.lang.String" resultType="com.m4gi.dto.CampgroundZoneDetailDTO">
+		SELECT 
+			zone_id, 
+			zone_name, 
+			zone_type, 
+			zone_terrain_type,
+			capacity, 
+			description,
+			zone_image
+		FROM campground_zones
+		WHERE zone_id = #{zoneId}
+		AND is_active = TRUE
+	</select>
+	
+	<select id="selectSitesDetailByZoneId" parameterType="java.lang.String" resultType="com.m4gi.dto.CampgroundSiteDTO">
+		SELECT 
+			site_id, 
+			site_name, 
+			width_meters, 
+			height_meters, 
+			capacity,
+			is_active
+		FROM campground_sites
+		WHERE zone_id = #{zoneId}
+		AND is_active = TRUE
+	</select>
+	
+	<select id="selectAvailableSitesByZoneId" parameterType="map" resultType="java.lang.String">
+		SELECT
+			cs.site_id
+		FROM campground_sites cs
+		WHERE cs.zone_id = #{zoneId}
+			AND cs.is_active = TRUE
+			AND cs.site_id NOT IN (
+				SELECT r.reservation_site
+				FROM reservations r
+				WHERE r.reservation_status = 1
+				AND (
+					(r.reservation_date &lt;= #{startDate} AND r.end_date &gt;= #{startDate})
+					OR
+					(r.reservation_date &lt;= #{endDate} AND r.end_date &gt;= #{endDate})
+					OR
+					(r.reservation_date &gt;= #{startDate} AND r.end_date &lt;= #{endDate})
+				)
+			)
+	</select>
+	
+	<select id="selectReviewsByZoneId" parameterType="java.lang.String" resultType="com.m4gi.dto.ReviewDTO">
+		SELECT
+			r.review_id,
+	        r.provider_code,
+	        r.provider_user_id,
+	        r.reservation_id,
+	        r.review_rating,
+	        r.review_content,
+	        r.review_photos AS reviewPhotosJson,
+	        r.created_at,
+	        r.updated_at,
+	        rv.checkin_time AS checkInTime,
+	        rv.checkout_time AS checkOutTime,
+	        cs.site_name
+        FROM campground_zones cz
+        JOIN campground_sites cs ON cs.zone_id = cz.zone_id
+        JOIN reservations rv ON cs.site_id = rv.reservation_site
+        JOIN reviews r ON rv.reservation_id = r.reservation_id
+        WHERE cz.zone_id = #{zoneId}
+	</select>
+	
+</mapper>


### PR DESCRIPTION
**구현 기능**
- 구역 정보, 해당 구역 내 사이트 정보 조회
- 예약 가능 + 활성화된 사이트만 선택 가능
- 사이트 선택 시 "예약하기" 버튼 활성화 처리


**수정사항**
- Swiper 이미지 슬라이드 구현을 위한 swiper 패키지 설치 → package.json, package-lock.json 수정
- App.css에 Swiper 스타일 및 공통 border, 검정 텍스트 색상 클래스 추가
- 백엔드: Zone 관련 Controller, Service, Mapper 신규 추가

**참고사항**
- 캠핑장 상세 페이지에서 구역 상세 페이지로 이동 시, 
→ URL 경로에 /detail/{campgroundId}/{zoneId}?startDate=...&endDate=...&people=... 형식으로 전달 
(Card.jsx에서 onClick에 navigate 로직 포함)

- 구역 상세 페이지에서 예약 페이지로 이동하는 기능 구현 완료 
→ state에 zoneId, startDate, endDate, people 포함하여 전달됨