### PR TITLE
Feature/camp searchpage/ksv

### DIFF
--- a/frontend/m4gi/src/components/Main/UI/FilterTagPresets.jsx
+++ b/frontend/m4gi/src/components/Main/UI/FilterTagPresets.jsx
@@ -33,19 +33,5 @@ export const tagPresets = [
             campgroundTypes: ["GLAMPING"],
         }
     },
-    {
-        label: "도심 속 가벼운 감성 캠프닉",
-        filters: {
-            featureList: ["CITY_VIEW", "PUBLIC_BBQ"],
-            campgroundTypes: ["GLAMPING"],
-        }
-    },
-    {
-        label: "도심 속 가벼운 감성 캠프닉",
-        filters: {
-            featureList: ["CITY_VIEW", "PUBLIC_BBQ"],
-            campgroundTypes: ["GLAMPING"],
-        }
-    }
 
 ];

--- a/frontend/m4gi/src/components/Main/UI/LazyImageCard.jsx
+++ b/frontend/m4gi/src/components/Main/UI/LazyImageCard.jsx
@@ -40,7 +40,7 @@ export default function Card({ site }) {
                     </div>
                     <div className="self-stretch text-right w-[120px]">
                         <div className="flex overflow-hidden flex-col justify-center items-end px-0.5 w-full">
-                            {isWishlisted === 1 ? (
+                            {isWishlisted == 1 ? (
                                 <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="size-6 text-fuchsia-700">
                                 <path strokeLinecap="round" strokeLinejoin="round" d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12Z" />
                                 </svg>

--- a/frontend/m4gi/src/components/Main/UI/RegionSelector.jsx
+++ b/frontend/m4gi/src/components/Main/UI/RegionSelector.jsx
@@ -2,45 +2,59 @@ import React, { useState, useEffect } from "react";
 
 // 지역 데이터
 const regionData = {
-  서울: ["강남구", "강동구", "강북구", "강서구", "관악구", "광진구", "구로구", "금천구", "노원구", "도봉구", "동대문구", "동작구", "마포구", "서대문구", "서초구", "성동구", "성북구", "송파구", "양천구", "영등포구", "용산구", "은평구", "종로구", "중구", "중랑구"],
-  부산: ["강서구", "금정구", "기장군", "남구", "동구", "동래구", "부산진구", "북구", "사상구", "사하구", "서구", "수영구", "연제구", "영도구", "중구", "해운대구"],
-  대구: ["남구", "달서구", "달성군", "동구", "북구", "서구", "수성구", "중구"],
-  인천: ["강화군", "계양구", "남동구", "동구", "미추홀구", "부평구", "서구", "연수구", "옹진군", "중구"],
-  광주: ["광산구", "남구", "동구", "북구", "서구"],
-  대전: ["대덕구", "동구", "서구", "유성구", "중구"],
-  울산: ["남구", "동구", "북구", "울주군", "중구"],
-  세종: ["세종특별자치시"],
-  경기: ["가평군", "고양시", "과천시", "광명시", "광주시", "구리시", "군포시", "김포시", "남양주시", "동두천시", "부천시", "성남시", "수원시", "시흥시", "안산시", "안성시", "안양시", "양주시", "양평군", "여주시", "연천군", "오산시", "용인시", "의왕시", "의정부시", "이천시", "파주시", "평택시", "포천시", "하남시", "화성시"],
-  강원: ["강릉시", "고성군", "동해시", "삼척시", "속초시", "양구군", "양양군", "영월군", "원주시", "인제군", "정선군", "철원군", "춘천시", "태백시", "평창군", "홍천군", "화천군"],
-  충북: ["괴산군", "단양군", "보은군", "영동군", "옥천군", "음성군", "제천시", "진천군", "청주시", "충주시"],
-  충남: ["계룡시", "공주시", "금산군", "논산시", "당진시", "보령시", "부여군", "서산시", "서천군", "아산시", "예산군", "천안시", "청양군", "태안군", "홍성군"],
-  전북: ["고창군", "군산시", "김제시", "남원시", "무주군", "부안군", "순창군", "완주군", "익산시", "임실군", "장수군", "전주시", "정읍시", "진안군"],
-  전남: ["강진군", "고흥군", "곡성군", "광양시", "구례군", "나주시", "담양군", "목포시", "무안군", "보성군", "순천시", "신안군", "여수시", "영광군", "영암군", "완도군", "장성군", "장흥군", "진도군", "함평군", "해남군"],
-  경북: ["경산시", "경주시", "고령군", "구미시", "김천시", "문경시", "봉화군", "상주시", "성주군", "안동시", "영덕군", "영양군", "영주시", "예천군", "울릉군", "울진군", "의성군", "청도군", "청송군", "칠곡군", "포항시"],
-  경남: ["거제시", "거창군", "고성군", "김해시", "남해군", "밀양시", "사천시", "산청군", "양산시", "의령군", "진주시", "창녕군", "창원시", "하동군", "함안군", "함양군", "합천군"],
-  제주: ["서귀포시", "제주시"],
+  서울특별시: ["강남구", "강동구", "강북구", "강서구", "관악구", "광진구", "구로구", "금천구", "노원구", "도봉구", "동대문구", "동작구", "마포구", "서대문구", "서초구", "성동구", "성북구", "송파구", "양천구", "영등포구", "용산구", "은평구", "종로구", "중구", "중랑구"],
+  부산광역시: ["강서구", "금정구", "기장군", "남구", "동구", "동래구", "부산진구", "북구", "사상구", "사하구", "서구", "수영구", "연제구", "영도구", "중구", "해운대구"],
+  대구광역시: ["남구", "달서구", "달성군", "동구", "북구", "서구", "수성구", "중구"],
+  인천광역시: ["강화군", "계양구", "남동구", "동구", "미추홀구", "부평구", "서구", "연수구", "옹진군", "중구"],
+  광주광역시: ["광산구", "남구", "동구", "북구", "서구"],
+  대전광역시: ["대덕구", "동구", "서구", "유성구", "중구"],
+  울산광역시: ["남구", "동구", "북구", "울주군", "중구"],
+  세종특별자치시: ["세종특별자치시"],
+  경기도: ["가평군", "고양시", "과천시", "광명시", "광주시", "구리시", "군포시", "김포시", "남양주시", "동두천시", "부천시", "성남시", "수원시", "시흥시", "안산시", "안성시", "안양시", "양주시", "양평군", "여주시", "연천군", "오산시", "용인시", "의왕시", "의정부시", "이천시", "파주시", "평택시", "포천시", "하남시", "화성시"],
+  강원도: ["강릉시", "고성군", "동해시", "삼척시", "속초시", "양구군", "양양군", "영월군", "원주시", "인제군", "정선군", "철원군", "춘천시", "태백시", "평창군", "홍천군", "화천군"],
+  충청북도: ["괴산군", "단양군", "보은군", "영동군", "옥천군", "음성군", "제천시", "진천군", "청주시", "충주시"],
+  충청남도: ["계룡시", "공주시", "금산군", "논산시", "당진시", "보령시", "부여군", "서산시", "서천군", "아산시", "예산군", "천안시", "청양군", "태안군", "홍성군"],
+  전라북도: ["고창군", "군산시", "김제시", "남원시", "무주군", "부안군", "순창군", "완주군", "익산시", "임실군", "장수군", "전주시", "정읍시", "진안군"],
+  전라남도: ["강진군", "고흥군", "곡성군", "광양시", "구례군", "나주시", "담양군", "목포시", "무안군", "보성군", "순천시", "신안군", "여수시", "영광군", "영암군", "완도군", "장성군", "장흥군", "진도군", "함평군", "해남군"],
+  경상북도: ["경산시", "경주시", "고령군", "구미시", "김천시", "문경시", "봉화군", "상주시", "성주군", "안동시", "영덕군", "영양군", "영주시", "예천군", "울릉군", "울진군", "의성군", "청도군", "청송군", "칠곡군", "포항시"],
+  경상남도: ["거제시", "거창군", "고성군", "김해시", "남해군", "밀양시", "사천시", "산청군", "양산시", "의령군", "진주시", "창녕군", "창원시", "하동군", "함안군", "함양군", "합천군"],
+  제주특별자치도: ["서귀포시", "제주시"],
 };
 
-export default function RegionSelector({ onSelectionChange }) {
+export default function RegionSelector({ onSelectionChange, selectedLocations }) {
   const [selectedCity, setSelectedCity] = useState(null);
   const [subRegions, setSubRegions] = useState([]);
-  const [selectedSiGunGu, setSelectedSiGunGu] = useState([]);
 
   const onCityClick = (city) => {
     setSelectedCity(city);
     setSubRegions(regionData[city] || []);
   };
 
-  const onSiGunGuClick = (siGunGu) => {
-    setSelectedSiGunGu((prev) =>
-      prev.includes(siGunGu) ? prev.filter((item) => item !== siGunGu) : prev.concat(siGunGu)
-    );
+  const onSiGunGuClick = (sigunguName) => {
+    const uniqueId = `${selectedCity}:${sigunguName}`;
+
+    const newSelection = selectedLocations.includes(uniqueId)
+      ? selectedLocations.filter((item) => item !== uniqueId)
+      : [...selectedLocations, uniqueId];
+    
+    onSelectionChange(newSelection);
   };
 
-  // selectedSiGunGu, onSelectionChange 상태가 바뀔 때 -> 부모 컴포넌트로 전달
-  useEffect(() => {
-    onSelectionChange(selectedSiGunGu);
-  }, [selectedSiGunGu, onSelectionChange]);
+  // '전체' 버튼 클릭 함수
+  const onSelectAllClick = () => {
+    const allSigungusForCity = regionData[selectedCity].map(sigungu => `${selectedCity}:${sigungu}`);
+    
+    const areAllSelected = allSigungusForCity.every(sigunguId => selectedLocations.includes(sigunguId));
+    
+    let newSelection;
+    if (areAllSelected) {
+      newSelection = selectedLocations.filter(loc => !loc.startsWith(`${selectedCity}:`));
+    } else {
+      const selectionSet = new Set([...selectedLocations, ...allSigungusForCity]);
+      newSelection = Array.from(selectionSet);
+    }
+    onSelectionChange(newSelection);
+  };
 
   return (
     <section className="p-5 text-base rounded-xl border-2 border-solid border-neutral-100 text-neutral-900">
@@ -58,31 +72,36 @@ export default function RegionSelector({ onSelectionChange }) {
         {selectedCity && subRegions.length > 0 && (
           <div className="flex flex-wrap gap-5 items-center mt-7 w-full leading-none text-center whitespace-nowrap">
             {/* 클릭 시, 해당 지역의 모든 시/군/구 선택됨 */}
-            <button type="button" className="w-[160px] p-2 my-auto cursor-pointer rounded-xl border-2 border-[#EDDDF4] border-opacity-20" 
-            onClick={() => {
-              setSelectedSiGunGu((prev) =>
-                prev.length === regionData[selectedCity].length ? [] : regionData[selectedCity]
-              );
-            }}>
+            <button 
+              type="button" 
+              className="w-[160px] p-2 my-auto cursor-pointer rounded-xl border-2 border-[#EDDDF4] border-opacity-20" 
+              onClick={onSelectAllClick}
+            >
               전체
             </button>
-            {subRegions.map((subRegion) => (
-              <button type="button" key={subRegion} onClick={() => onSiGunGuClick(subRegion)}
-                className={`w-[160px] p-2 rounded-xl cursor-pointer border-2 border-[#EDDDF4] ${
-                  selectedSiGunGu.includes(subRegion)
-                    ? "bg-clpurple text-cpurple"
-                    : "border-opacity-20"
-                }`}>
-                {subRegion}
-              </button>
-            ))}
+            {subRegions.map((subRegion) => {
+              const uniqueId = `${selectedCity}:${subRegion}`;
+              const isSelected = selectedLocations.includes(uniqueId);
+              return (
+                <button 
+                  type="button" 
+                  key={uniqueId}
+                  onClick={() => onSiGunGuClick(subRegion)}
+                  className={`w-[160px] p-2 rounded-xl cursor-pointer border-2 border-[#EDDDF4] ${
+                    isSelected ? "bg-clpurple text-cpurple" : "border-opacity-20"
+                  }`}
+                >
+                  {subRegion}
+                </button>
+              );
+          })}
           </div>
         )}
       </div>
       <div className="text-right pr-2.5 mt-2.5">
         <span
           type="button"
-          onClick={() => setSelectedSiGunGu([])}
+          onClick={() => onSelectionChange([])}
           className="text-cpurple cursor-pointer"
         >
           초기화

--- a/frontend/m4gi/src/components/Main/UI/SearchForm.jsx
+++ b/frontend/m4gi/src/components/Main/UI/SearchForm.jsx
@@ -56,8 +56,6 @@ export default function SearchForm() {
     if (startDate) params.set("startDate", startDate);
     if (endDate) params.set("endDate", endDate);
     params.set("people", people.toString());
-    params.set("providerCode", "1"); // 임시 고정
-    params.set("providerUserId", "puid_0001");
 
     navigate(`/searchResult?${params.toString()}`);
   };

--- a/frontend/m4gi/src/components/Main/UI/SearchForm.jsx
+++ b/frontend/m4gi/src/components/Main/UI/SearchForm.jsx
@@ -24,7 +24,7 @@ export default function SearchForm() {
   
   // ★ 검색 결과 페이지 url에 담아갈 내용들 변환 및 페이지 이동
   const [campgroundName, setCampgroundName] = useState("");
-  const [addrSigunguList, setAddrSigunguList] = useState([]);
+  const [selectedLocations, setSelectedLocations] = useState([]);
   const [startDate, setStartDate] = useState("");
   const [endDate, setEndDate] = useState("");
   const [people, setPeople] = useState(2);
@@ -48,9 +48,9 @@ export default function SearchForm() {
     const params = new URLSearchParams();
     
     if (campgroundName) params.set("campgroundName", campgroundName);
-    if (addrSigunguList.length > 0) {
-      addrSigunguList.forEach(sigungu => {
-        params.append("addrSigunguList", sigungu);
+    if (selectedLocations.length > 0) {
+      selectedLocations.forEach(location => {
+        params.append("locations", location);
       });
     }
     if (startDate) params.set("startDate", startDate);
@@ -81,16 +81,22 @@ export default function SearchForm() {
         >
           <SearchInput
             icon="https://cdn.builder.io/api/v1/image/assets/TEMP/d6876cee698c54e2e3a35f480d4405064ad5dc80?placeholderIfAbsent=true&apiKey=4d86e9992856436e99337ef794fe12ef"
-            placeholder={addrSigunguList.length > 0 ? addrSigunguList.join(', ') : "지역을 선택 해주세요."}
-            value={addrSigunguList.join(', ')}
+            placeholder={
+              selectedLocations.length > 0 
+              ? selectedLocations.map(loc => loc.replace(':', ' ')).join(', ') 
+              : "지역을 선택 해주세요."
+            }
+            value={selectedLocations.map(loc => loc.replace(':', ' ')).join(', ')}
             iconAlt="Location icon"
+            readOnly
           />
         </div>
         {activeSelector === 'region' && (
           <RegionSelector
-            onSelectionChange={(selectedRegions) => {
-              setAddrSigunguList(selectedRegions);
+            onSelectionChange={(selected) => {
+              setSelectedLocations(selected);
             }}
+            selectedLocations={selectedLocations}
           />
         )}
 

--- a/frontend/m4gi/src/pages/Main/Main_CampSearchResultPage.jsx
+++ b/frontend/m4gi/src/pages/Main/Main_CampSearchResultPage.jsx
@@ -63,8 +63,6 @@ export default function CampingSearchResultPage () {
       startDate: queryParams.get("startDate") || "",
       endDate: queryParams.get("endDate") || "",
       people: Number(queryParams.get("people") || 2),
-      providerCode: queryParams.get("providerCode") || "",
-      providerUserId: queryParams.get("providerUserId") || "",
     };
     setSearchParams(restoredParams);
     setPage(0);

--- a/frontend/m4gi/src/pages/Main/Main_CampSearchResultPage.jsx
+++ b/frontend/m4gi/src/pages/Main/Main_CampSearchResultPage.jsx
@@ -59,7 +59,7 @@ export default function CampingSearchResultPage () {
     const restoredParams = {
       campgroundId: queryParams.get("campgroundId") || "",
       campgroundName: queryParams.get("campgroundName") || "",
-      addrSigunguList: queryParams.getAll("addrSigunguList"),
+      locations: queryParams.getAll("locations"), 
       startDate: queryParams.get("startDate") || "",
       endDate: queryParams.get("endDate") || "",
       people: Number(queryParams.get("people") || 2),

--- a/workspace_project/Project/src/main/java/com/m4gi/controller/CampgroundController.java
+++ b/workspace_project/Project/src/main/java/com/m4gi/controller/CampgroundController.java
@@ -4,6 +4,8 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 
+import javax.servlet.http.HttpSession;
+
 import org.springframework.format.annotation.DateTimeFormat;
 import com.m4gi.dto.CampgroundDTO;
 import org.springframework.http.HttpStatus;
@@ -35,12 +37,13 @@ public class CampgroundController {
 			@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
 			@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
 			@RequestParam(required = false) Integer people,
-			@RequestParam(required = false) Integer providerCode,
-			@RequestParam(required = false) String providerUserId,
 			@RequestParam(required = false, defaultValue = "price_high") String sortOption,
 			@RequestParam(defaultValue = "10") int limit,
 			@RequestParam(defaultValue = "0") int offset,
-			@ModelAttribute CampgroundFilterRequestDTO filterDTO) {
+			@ModelAttribute CampgroundFilterRequestDTO filterDTO, HttpSession session) {
+		
+		Integer providerCode = (Integer) session.getAttribute("providerCode");
+		String providerUserId = (String) session.getAttribute("providerUserId");
 
 		List<CampgroundCardDTO> searchedCampgrounds = campgroundService.searchCampgrounds(
 				campgroundName, locations, startDate, endDate, people, 

--- a/workspace_project/Project/src/main/java/com/m4gi/controller/CampgroundController.java
+++ b/workspace_project/Project/src/main/java/com/m4gi/controller/CampgroundController.java
@@ -31,7 +31,7 @@ public class CampgroundController {
 	@GetMapping("/searchResult")
 	public ResponseEntity<List<CampgroundCardDTO>> searchCampgrounds(
 			@RequestParam(required = false) String campgroundName,
-			@RequestParam(required = false) List<String> addrSigunguList,
+			@RequestParam(required = false) List<String> locations,
 			@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
 			@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
 			@RequestParam(required = false) Integer people,
@@ -42,20 +42,11 @@ public class CampgroundController {
 			@RequestParam(defaultValue = "0") int offset,
 			@ModelAttribute CampgroundFilterRequestDTO filterDTO) {
 
-		CampgroundSearchDTO searchDTO = new CampgroundSearchDTO();
-		searchDTO.setCampgroundName(campgroundName);
-		searchDTO.setAddrSigunguList(addrSigunguList);
-		searchDTO.setStartDate(startDate);
-		searchDTO.setEndDate(endDate);
-		searchDTO.setPeople(people != null ? people : 2);
-		searchDTO.setProviderCode(providerCode != null ? providerCode : 0);
-		searchDTO.setProviderUserId(providerUserId);
-		searchDTO.setSortOption(sortOption);
-		searchDTO.setLimit(limit);
-		searchDTO.setOffset(offset);
-
-		List<CampgroundCardDTO> searchedCampgrounds = campgroundService.searchCampgrounds(searchDTO, filterDTO);
-
+		List<CampgroundCardDTO> searchedCampgrounds = campgroundService.searchCampgrounds(
+				campgroundName, locations, startDate, endDate, people, 
+				providerCode, providerUserId, sortOption, limit, offset, filterDTO
+		);
+		
 		if (searchedCampgrounds != null && !searchedCampgrounds.isEmpty()) {
 			return new ResponseEntity<>(searchedCampgrounds, HttpStatus.OK);
 		} else {

--- a/workspace_project/Project/src/main/java/com/m4gi/dto/CampgroundSearchDTO.java
+++ b/workspace_project/Project/src/main/java/com/m4gi/dto/CampgroundSearchDTO.java
@@ -9,10 +9,12 @@ import lombok.Data;
 public class CampgroundSearchDTO {
     // 검색 조건
     private String campgroundName;
-    private List<String> addrSigunguList;
     private LocalDate startDate;
     private LocalDate endDate;
     private int people;
+
+    // (시도, 시군구) 쌍의 리스트
+    private List<LocationDTO> locations; 
 
     // 정렬 조건
     private String sortOption; // "price_low", "price_high", "rating", "popularity", "latest"

--- a/workspace_project/Project/src/main/java/com/m4gi/dto/LocationDTO.java
+++ b/workspace_project/Project/src/main/java/com/m4gi/dto/LocationDTO.java
@@ -1,0 +1,13 @@
+package com.m4gi.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class LocationDTO {
+    private String sido;
+    private String sigungu;
+}

--- a/workspace_project/Project/src/main/java/com/m4gi/service/CampgroundService.java
+++ b/workspace_project/Project/src/main/java/com/m4gi/service/CampgroundService.java
@@ -1,5 +1,6 @@
 package com.m4gi.service;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 
@@ -8,7 +9,9 @@ import com.m4gi.dto.*;
 public interface CampgroundService {
 
 	// 캠핑장 검색 목록 조회
-	List<CampgroundCardDTO> searchCampgrounds(CampgroundSearchDTO searchDTO, CampgroundFilterRequestDTO filterDTO);
+	List<CampgroundCardDTO> searchCampgrounds(String campgroundName, List<String> locations, LocalDate startDate,
+			LocalDate endDate, Integer people, Integer providerCode, String providerUserId,
+			String sortOption, int limit, int offset, CampgroundFilterRequestDTO filterDTO);
 
 	Map<String, Object> getCampgroundById(int campgroundId);
 

--- a/workspace_project/Project/src/main/java/com/m4gi/service/CampgroundServiceImpl.java
+++ b/workspace_project/Project/src/main/java/com/m4gi/service/CampgroundServiceImpl.java
@@ -1,6 +1,7 @@
 package com.m4gi.service;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -21,40 +22,49 @@ public class CampgroundServiceImpl implements CampgroundService {
 
 	// 캠핑장 검색 목록 조회
 	@Override
-	public List<CampgroundCardDTO> searchCampgrounds(CampgroundSearchDTO searchDTO,
-			CampgroundFilterRequestDTO filterDTO) {
-		// 기본값 설정
-		if (searchDTO.getCampgroundName() == null)
-			searchDTO.setCampgroundName("");
-		if (searchDTO.getStartDate() == null)
-			searchDTO.setStartDate(LocalDate.now());
-		if (searchDTO.getEndDate() == null)
-			searchDTO.setEndDate(LocalDate.now().plusDays(1));
-		if (searchDTO.getPeople() == 0)
-			searchDTO.setPeople(2); // 기본 인원
-		if (searchDTO.getLimit() == 0)
-			searchDTO.setLimit(10);
-		if (searchDTO.getOffset() < 0)
-			searchDTO.setOffset(0);
-
-		// 모든 필터가 비어있다면
-		boolean isAllFilterEmpty = (filterDTO.getCampgroundTypes() == null || filterDTO.getCampgroundTypes().isEmpty())
-				&&
-				(filterDTO.getSiteEnviroments() == null || filterDTO.getSiteEnviroments().isEmpty()) &&
-				(filterDTO.getFeatureList() == null || filterDTO.getFeatureList().isEmpty());
-
-		if (isAllFilterEmpty) {
-			// 필터 조건이 아무것도 없으면 전체 검색 (필터링 조건 추가 X)
-			return campgroundMapper.selectSearchedCampgrounds(searchDTO);
+	public List<CampgroundCardDTO> searchCampgrounds(String campgroundName, List<String> locations, LocalDate startDate,
+			LocalDate endDate, Integer people, Integer providerCode, String providerUserId,
+			String sortOption, int limit, int offset, CampgroundFilterRequestDTO filterDTO) {
+		
+		CampgroundSearchDTO searchDTO = new CampgroundSearchDTO();
+		
+		// 기본값 설정 및 DTO에 값 채우기
+		searchDTO.setCampgroundName(campgroundName != null ? campgroundName : "");
+		searchDTO.setStartDate(startDate != null ? startDate : LocalDate.now());
+		searchDTO.setEndDate(endDate != null ? endDate : LocalDate.now().plusDays(1));
+		searchDTO.setPeople(people != null ? people : 2);
+		searchDTO.setProviderCode(providerCode != null ? providerCode : 0);
+		searchDTO.setProviderUserId(providerUserId);
+		searchDTO.setSortOption(sortOption);
+		searchDTO.setLimit(limit);
+		searchDTO.setOffset(offset);
+		
+		// "시도:시군구" 문자열 리스트를 List<LocationDTO> 객체 리스트로 변환
+		if (locations != null && !locations.isEmpty()) {
+			List<LocationDTO> locationPairs = new ArrayList<>();
+			for (String loc : locations) {
+				String[] parts = loc.split(":"); // "인천:동구" -> ["인천", "동구"]
+				if (parts.length == 2) {
+					locationPairs.add(new LocationDTO(parts[0], parts[1]));
+				}
+			}
+			searchDTO.setLocations(locationPairs);
 		}
+		
+		// 부가 필터(캠핑장 유형, 환경 등) 처리
+		boolean isFilterEmpty = (filterDTO.getCampgroundTypes() == null || filterDTO.getCampgroundTypes().isEmpty()) &&
+							    (filterDTO.getSiteEnviroments() == null || filterDTO.getSiteEnviroments().isEmpty()) &&
+							    (filterDTO.getFeatureList() == null || filterDTO.getFeatureList().isEmpty());
 
-		// 필터 조건이 있다면 전체 검색(필터링 조건 추가 O)
-		List<Integer> filteredIds = campgroundMapper.selectCampgroundIdsByFilter(filterDTO);
-
-		if (filteredIds != null && !filteredIds.isEmpty()) {
+		if (!isFilterEmpty) {
+			List<Integer> filteredIds = campgroundMapper.selectCampgroundIdsByFilter(filterDTO);
+			// 필터 결과가 없으면, 검색 결과도 없어야 하므로 빈 리스트를 반환
+			if (filteredIds == null || filteredIds.isEmpty()) {
+				return Collections.emptyList();
+			}
 			searchDTO.setCampgroundIdList(filteredIds);
 		}
-
+		
 		return campgroundMapper.selectSearchedCampgrounds(searchDTO);
 	}
 

--- a/workspace_project/Project/src/main/resources/mapper/CampgroundMapper.xml
+++ b/workspace_project/Project/src/main/resources/mapper/CampgroundMapper.xml
@@ -82,12 +82,13 @@
 			</foreach>
 		</if>
 		
-	    <if test="addrSigunguList != null and !addrSigunguList.isEmpty()">
-		  AND c.addr_sigungu IN
-		  <foreach item="sigungu" collection="addrSigunguList" open="(" separator="," close=")">
-		    #{sigungu}
-		  </foreach>
-		</if>
+		<if test="locations != null and !locations.isEmpty()">
+            AND (
+                <foreach collection="locations" item="loc" separator=" OR ">
+                    (c.addr_sido = #{loc.sido} AND c.addr_sigungu = #{loc.sigungu})
+                </foreach>
+            )
+        </if>
 	
 	    <if test="startDate != null and endDate != null">
 	    AND NOT EXISTS (


### PR DESCRIPTION
**변경 사항**
- 중복된 필터태그 제거
- 하드코딩되어있던 부분 수정
- 검색 관련 문제로 인해 코드 수정
```
문제 상황: 
예를 들어 "인천 전체" 선택 후 검색 시, 인천뿐 아니라 대구 등의 캠핑장도 함께 조회됨

원인 분석: 
"중구", "동구"처럼 여러 시/도에서 동일한 시/군/구 명칭을 사용하는 경우, 
해당 명칭이 포함된 모든 지역이 검색 결과에 포함됨

해결 방법: 
"시도:시군구" 형태로 지역을 고유하게 식별할 수 있도록 구조를 변경하고, 
이 형식에 맞춰 상태 관리 및 API 요청 로직을 전면 수정
```

**참고 사항**
- 기존에 하드코딩되어 있던 provider_code, provider_user_id는 제거한 후, 세션으로 받았습니다.
- 해당 정보는 검색 결과 카드 UI에서 찜 여부 표시에 필요하여 사용되었습니다. 

![image](https://github.com/user-attachments/assets/e5b58678-7b23-4b00-bf72-b0b641f8e774)
▲ 문제가 된 상황 캡처본 (인천 전체 검색 한 상태)

![image](https://github.com/user-attachments/assets/f8bfe84f-ac7e-4575-b8c9-e70055b65d58)
▲ 로그인한 상태에서 해당 캠핑장을 찜한 경우 → 채워진 하트 아이콘 표시